### PR TITLE
Noise Confidence Interval for Gaussian Noise 

### DIFF
--- a/cc/algorithms/numerical-mechanisms.h
+++ b/cc/algorithms/numerical-mechanisms.h
@@ -76,7 +76,12 @@ class NumericalMechanism {
 
   virtual base::StatusOr<ConfidenceInterval> NoiseConfidenceInterval(
       double confidence_level, double privacy_budget,
-      double noised_result = 0) {
+      double noised_result) {
+    return base::UnimplementedError(
+        "NoiseConfidenceInterval() unsupported for this numerical mechanism.");
+  }
+  virtual base::StatusOr<ConfidenceInterval> NoiseConfidenceInterval(
+      double confidence_level, double privacy_budget) {
     return base::UnimplementedError(
         "NoiseConfidenceInterval() unsupported for this numerical mechanism.");
   }
@@ -304,8 +309,13 @@ class LaplaceMechanism : public NumericalMechanism {
   // If the returned value is <x,y>, then the noise added has a confidence_level
   // chance of being in the domain [x,y].
   base::StatusOr<ConfidenceInterval> NoiseConfidenceInterval(
+      double confidence_level, double privacy_budget) override {
+    return NoiseConfidenceInterval(confidence_level, privacy_budget, 0);
+  }
+
+  base::StatusOr<ConfidenceInterval> NoiseConfidenceInterval(
       double confidence_level, double privacy_budget,
-      double noised_result = 0) override {
+      double noised_result) override {
     base::Status status = CheckConfidenceLevel(confidence_level);
     status.Update(CheckPrivacyBudget(privacy_budget));
     if (!status.ok()) {
@@ -427,7 +437,7 @@ class GaussianMechanism : public NumericalMechanism {
   // chance of being in the domain [x,y].
 
   base::StatusOr<ConfidenceInterval> NoiseConfidenceInterval(
-      double confidence_level, double privacy_budget) {
+      double confidence_level, double privacy_budget) override {
     return NoiseConfidenceInterval(confidence_level, privacy_budget, 0);
   }
 

--- a/cc/algorithms/numerical-mechanisms.h
+++ b/cc/algorithms/numerical-mechanisms.h
@@ -436,6 +436,8 @@ class GaussianMechanism : public NumericalMechanism {
     double stddev = CalculateStddev(local_epsilon, local_delta);
 
     ConfidenceInterval confidence;
+    // calculated using the symmetric properties of the Gaussian distribution
+    // and the cumulative distribution function for the distribution
     float bound = inverseErrorFunction(-1*confidence_level)*stddev*std::sqrt(2);
     confidence.set_lower_bound(bound);
     confidence.set_upper_bound(-bound);

--- a/cc/algorithms/numerical-mechanisms.h
+++ b/cc/algorithms/numerical-mechanisms.h
@@ -75,7 +75,8 @@ class NumericalMechanism {
   virtual int64_t MemoryUsed() = 0;
 
   virtual base::StatusOr<ConfidenceInterval> NoiseConfidenceInterval(
-      double confidence_level, double privacy_budget, double noised_result = 0) {
+      double confidence_level, double privacy_budget,
+      double noised_result = 0) {
     return base::UnimplementedError(
         "NoiseConfidenceInterval() unsupported for this numerical mechanism.");
   }
@@ -303,7 +304,8 @@ class LaplaceMechanism : public NumericalMechanism {
   // If the returned value is <x,y>, then the noise added has a confidence_level
   // chance of being in the domain [x,y].
   base::StatusOr<ConfidenceInterval> NoiseConfidenceInterval(
-      double confidence_level, double privacy_budget, double noised_result = 0) override {
+      double confidence_level, double privacy_budget,
+      double noised_result = 0) override {
     base::Status status = CheckConfidenceLevel(confidence_level);
     status.Update(CheckPrivacyBudget(privacy_budget));
     if (!status.ok()) {
@@ -424,7 +426,8 @@ class GaussianMechanism : public NumericalMechanism {
   // If the returned value is <x,y>, then the noise added has a confidence_level
   // chance of being in the domain [x,y].
   base::StatusOr<ConfidenceInterval> NoiseConfidenceInterval(
-      double confidence_level, double privacy_budget, double noised_result = 0) override {
+      double confidence_level, double privacy_budget,
+      double noised_result = 0) override {
     base::Status status = CheckConfidenceLevel(confidence_level);
     status.Update(CheckPrivacyBudget(privacy_budget));
     if (!status.ok()) {

--- a/cc/algorithms/numerical-mechanisms.h
+++ b/cc/algorithms/numerical-mechanisms.h
@@ -425,9 +425,16 @@ class GaussianMechanism : public NumericalMechanism {
   // noise that AddNoise() would add with the specified privacy budget.
   // If the returned value is <x,y>, then the noise added has a confidence_level
   // chance of being in the domain [x,y].
+
+  base::StatusOr<ConfidenceInterval> NoiseConfidenceInterval(
+      double confidence_level, double privacy_budget) {
+    return NoiseConfidenceInterval(confidence_level, privacy_budget, 0);
+  }
+
+
   base::StatusOr<ConfidenceInterval> NoiseConfidenceInterval(
       double confidence_level, double privacy_budget,
-      double noised_result = 0) override {
+      double noised_result) override {
     base::Status status = CheckConfidenceLevel(confidence_level);
     status.Update(CheckPrivacyBudget(privacy_budget));
     if (!status.ok()) {

--- a/cc/algorithms/numerical-mechanisms.h
+++ b/cc/algorithms/numerical-mechanisms.h
@@ -438,7 +438,7 @@ class GaussianMechanism : public NumericalMechanism {
     ConfidenceInterval confidence;
     // calculated using the symmetric properties of the Gaussian distribution
     // and the cumulative distribution function for the distribution
-    float bound = inverseErrorFunction(-1*confidence_level)*stddev*std::sqrt(2);
+    float bound = InverseErrorFunction(-1*confidence_level)*stddev*std::sqrt(2);
     confidence.set_lower_bound(bound);
     confidence.set_upper_bound(-bound);
     confidence.set_confidence_level(confidence_level);

--- a/cc/algorithms/numerical-mechanisms.h
+++ b/cc/algorithms/numerical-mechanisms.h
@@ -436,8 +436,7 @@ class GaussianMechanism : public NumericalMechanism {
     double stddev = CalculateStddev(local_epsilon, local_delta);
 
     ConfidenceInterval confidence;
-    float x = -1*confidence_level;
-    float bound = inverseErrorFunction(x)*stddev*std::sqrt(2);
+    float bound = inverseErrorFunction(-1*confidence_level)*stddev*std::sqrt(2);
     confidence.set_lower_bound(bound);
     confidence.set_upper_bound(-bound);
     confidence.set_confidence_level(confidence_level);
@@ -450,6 +449,11 @@ class GaussianMechanism : public NumericalMechanism {
 
   double GetL2Sensitivity() { return l2_sensitivity_; }
 
+ private:
+  double delta_;
+  double l2_sensitivity_;
+  std::unique_ptr<internal::GaussianDistribution> distro_;
+
   // Calculate the required standard deviation for provided epsilon and delta.
   // This formula can be derived from Proposition 3 and Corollary 3 of Ilya's
   // paper on Renyi DP (https://arxiv.org/abs/1702.07476v3).
@@ -459,11 +463,6 @@ class GaussianMechanism : public NumericalMechanism {
            (std::sqrt(logOneDivDelta + epsilon / l2_sensitivity_) +
             std::sqrt(logOneDivDelta));
   }
-
- private:
-  double delta_;
-  double l2_sensitivity_;
-  std::unique_ptr<internal::GaussianDistribution> distro_;
 };
 
 }  // namespace differential_privacy

--- a/cc/algorithms/numerical-mechanisms_test.cc
+++ b/cc/algorithms/numerical-mechanisms_test.cc
@@ -196,8 +196,8 @@ TEST(NumericalMechanismsTest, LaplaceConfidenceInterval) {
             result + (log(1 - level) / epsilon / budget));
   EXPECT_EQ(confidence_interval_with_result.ValueOrDie().upper_bound(),
             result - (log(1 - level) / epsilon / budget));
-  EXPECT_EQ(confidence_interval_with_result.ValueOrDie().confidence_level(), level);
-
+  EXPECT_EQ(confidence_interval_with_result.ValueOrDie().confidence_level(),
+   level);
 }
 
 TYPED_TEST(NumericalMechanismsTest, LaplaceBuilderClone) {
@@ -291,7 +291,7 @@ TEST(NumericalMechanismsTest, GaussNoiseConfidenceInterval) {
   double sensitivities[] = {1.0, 1.0, 1.0};
   double levels[] = {.9, .95, .95};
   double budgets[] = {.5, .5, .75};
-  double results[] = {0,1.3,2.7};
+  double results[] = {0, 1.3, 2.7};
   // calculated using standard deviations of
   // 3.4855, 3.60742, 0.367936 respectively
   double true_bounds[] = {-5.733, -7.07, -0.7211};

--- a/cc/algorithms/numerical-mechanisms_test.cc
+++ b/cc/algorithms/numerical-mechanisms_test.cc
@@ -272,7 +272,7 @@ TEST(NumericalMechanismsTest, GaussNoiseConfidenceInterval) {
   // Tests the NoiseConfidenceInterval method for Gaussian noise.
   // Standard deviations are pre-calculated using CalculateStdDev
   // in the Gaussian mechanism class. True bounds are also pre-calculated
-  // using a confidence interval calcualtor. 
+  // using a confidence interval calcualtor.
 
   int NUM_TESTS = 3;
   double epsilons[] = {1.2, 1.0, 10.0};
@@ -280,11 +280,11 @@ TEST(NumericalMechanismsTest, GaussNoiseConfidenceInterval) {
   double sensitivities[] = {1.0, 1.0, 1.0};
   double levels[] = {.9, .95, .95};
   double budgets[] = {.5, .5, .75};
-  // calculated using standard deviations of 
-  // 3.4855, 3.60742, 0.367936 respectively 
+  // calculated using standard deviations of
+  // 3.4855, 3.60742, 0.367936 respectively
   double true_bounds[] = {-5.733, -7.07, -0.7211};
 
-  for (int i = 0; i < NUM_TESTS; i++){
+  for (int i = 0; i < NUM_TESTS; i++) {
     double epsilon = epsilons[i];
     double delta = deltas[i];
     double sensitivity = sensitivities[i];
@@ -299,12 +299,11 @@ TEST(NumericalMechanismsTest, GaussNoiseConfidenceInterval) {
 
     EXPECT_TRUE(confidence_interval.ok());
     EXPECT_NEAR(confidence_interval.ValueOrDie().lower_bound(),
-            true_lower_bound,0.001);
+            true_lower_bound, 0.001);
     EXPECT_NEAR(confidence_interval.ValueOrDie().upper_bound(),
-            true_upper_bound,0.001);
+            true_upper_bound, 0.001);
     EXPECT_EQ(confidence_interval.ValueOrDie().confidence_level(), level);
   }
-
 }
 
 TEST(NumericalMechanismsTest, GaussianBuilderClone) {

--- a/cc/algorithms/numerical-mechanisms_test.cc
+++ b/cc/algorithms/numerical-mechanisms_test.cc
@@ -187,6 +187,17 @@ TEST(NumericalMechanismsTest, LaplaceConfidenceInterval) {
   EXPECT_EQ(confidence_interval.ValueOrDie().upper_bound(),
             -log(1 - level) / epsilon / budget);
   EXPECT_EQ(confidence_interval.ValueOrDie().confidence_level(), level);
+
+  double result = 19.3;
+  base::StatusOr<ConfidenceInterval> confidence_interval_with_result =
+      mechanism.NoiseConfidenceInterval(level, budget, result);
+  EXPECT_TRUE(confidence_interval.ok());
+  EXPECT_EQ(confidence_interval_with_result.ValueOrDie().lower_bound(),
+            result + (log(1 - level) / epsilon / budget));
+  EXPECT_EQ(confidence_interval_with_result.ValueOrDie().upper_bound(),
+            result - (log(1 - level) / epsilon / budget));
+  EXPECT_EQ(confidence_interval_with_result.ValueOrDie().confidence_level(), level);
+
 }
 
 TYPED_TEST(NumericalMechanismsTest, LaplaceBuilderClone) {
@@ -280,6 +291,7 @@ TEST(NumericalMechanismsTest, GaussNoiseConfidenceInterval) {
   double sensitivities[] = {1.0, 1.0, 1.0};
   double levels[] = {.9, .95, .95};
   double budgets[] = {.5, .5, .75};
+  double results[] = {0,1.3,2.7};
   // calculated using standard deviations of
   // 3.4855, 3.60742, 0.367936 respectively
   double true_bounds[] = {-5.733, -7.07, -0.7211};
@@ -290,12 +302,13 @@ TEST(NumericalMechanismsTest, GaussNoiseConfidenceInterval) {
     double sensitivity = sensitivities[i];
     double level = levels[i];
     double budget = budgets[i];
-    float true_lower_bound = true_bounds[i];
-    float true_upper_bound = -true_bounds[i];
+    double result = results[i];
+    double true_lower_bound = result + true_bounds[i];
+    double true_upper_bound = result - true_bounds[i];
 
     GaussianMechanism mechanism(epsilon, delta, sensitivity);
     base::StatusOr<ConfidenceInterval> confidence_interval =
-      mechanism.NoiseConfidenceInterval(level, budget);
+      mechanism.NoiseConfidenceInterval(level, budget, result);
 
     EXPECT_TRUE(confidence_interval.ok());
     EXPECT_NEAR(confidence_interval.ValueOrDie().lower_bound(),

--- a/cc/algorithms/numerical-mechanisms_test.cc
+++ b/cc/algorithms/numerical-mechanisms_test.cc
@@ -268,29 +268,77 @@ TEST(NumericalMechanismsTest, GaussianMechanismAddsNoise) {
   EXPECT_FALSE(std::isnan(mechanism.AddNoise(1.1, -2.0)));
 }
 
-TEST(NumericalMechanismsTest, GaussConfidenceInterval) {
-  double epsilon = 1.0;
-  double delta = 0.5;
+TEST(NumericalMechanismsTest, GaussNoiseConfidenceInterval) {
+  // Tests the NoiseConfidenceInterval method for Gaussian noise.
+  // Standard deviations are pre-calculated using CalculateStdDev
+  // in the Gaussian mechanism class. True bounds are also pre-calculated
+  // using a confidence interval calcualtor. 
+
+  // first test
+  // stddev of 3.4855 for confidence interval calculation 
+  double epsilon = 1.2;
+  double delta = 0.3;
   double sensitivity = 1.0;
-  double level = .95;
+  double level = .9;
   double budget = .5;
 
   GaussianMechanism mechanism(epsilon, delta, sensitivity);
   base::StatusOr<ConfidenceInterval> confidence_interval =
       mechanism.NoiseConfidenceInterval(level, budget);
 
-  double stddev = mechanism.CalculateStddev(budget*epsilon, budget*delta);
-
-  float x = -1*level;
-  float bound = inverseErrorFunction(x)*stddev*std::sqrt(2);
-
+  float true_lower_bound = -5.733;
+  float true_upper_bound = 5.733;
 
   EXPECT_TRUE(confidence_interval.ok());
-  EXPECT_EQ(confidence_interval.ValueOrDie().lower_bound(),
-            bound);
-  EXPECT_EQ(confidence_interval.ValueOrDie().upper_bound(),
-            -1*bound);
+  EXPECT_NEAR(confidence_interval.ValueOrDie().lower_bound(),
+            true_lower_bound,0.001);
+  EXPECT_NEAR(confidence_interval.ValueOrDie().upper_bound(),
+            true_upper_bound,0.001);
   EXPECT_EQ(confidence_interval.ValueOrDie().confidence_level(), level);
+
+  // second test 
+  // stddev of 3.60742 for confidence interval calculation
+  epsilon = 1.0;
+  delta = 0.5;
+  sensitivity = 1.0;
+  level = .95;
+  budget = .5;
+
+  GaussianMechanism second_mechanism(epsilon, delta, sensitivity);
+  confidence_interval = second_mechanism.NoiseConfidenceInterval(level, budget);
+
+  true_lower_bound = -7.07;
+  true_upper_bound = 7.07;
+
+  EXPECT_TRUE(confidence_interval.ok());
+  EXPECT_NEAR(confidence_interval.ValueOrDie().lower_bound(),
+            true_lower_bound,0.001);
+  EXPECT_NEAR(confidence_interval.ValueOrDie().upper_bound(),
+            true_upper_bound,0.001);
+  EXPECT_EQ(confidence_interval.ValueOrDie().confidence_level(), level);
+
+  // third test 
+  // stddev of 0.367936 for confidence interval calculation
+  epsilon = 10.0;
+  delta = 0.5;
+  sensitivity = 1.0;
+  level = .95;
+  budget = .75;
+
+  GaussianMechanism third_mechanism(epsilon, delta, sensitivity);
+  confidence_interval = third_mechanism.NoiseConfidenceInterval(level, budget);
+
+  true_lower_bound = -0.7211;
+  true_upper_bound = 0.7211;
+
+  EXPECT_TRUE(confidence_interval.ok());
+  EXPECT_NEAR(confidence_interval.ValueOrDie().lower_bound(),
+            true_lower_bound,0.0001);
+  EXPECT_NEAR(confidence_interval.ValueOrDie().upper_bound(),
+            true_upper_bound,0.0001);
+  EXPECT_EQ(confidence_interval.ValueOrDie().confidence_level(), level);
+
+
 }
 
 TEST(NumericalMechanismsTest, GaussianBuilderClone) {

--- a/cc/algorithms/numerical-mechanisms_test.cc
+++ b/cc/algorithms/numerical-mechanisms_test.cc
@@ -274,70 +274,36 @@ TEST(NumericalMechanismsTest, GaussNoiseConfidenceInterval) {
   // in the Gaussian mechanism class. True bounds are also pre-calculated
   // using a confidence interval calcualtor. 
 
-  // first test
-  // stddev of 3.4855 for confidence interval calculation 
-  double epsilon = 1.2;
-  double delta = 0.3;
-  double sensitivity = 1.0;
-  double level = .9;
-  double budget = .5;
+  int NUM_TESTS = 3;
+  double epsilons[] = {1.2, 1.0, 10.0};
+  double deltas[] = {0.3, 0.5, 0.5};
+  double sensitivities[] = {1.0, 1.0, 1.0};
+  double levels[] = {.9, .95, .95};
+  double budgets[] = {.5, .5, .75};
+  // calculated using standard deviations of 
+  // 3.4855, 3.60742, 0.367936 respectively 
+  double true_bounds[] = {-5.733, -7.07, -0.7211};
 
-  GaussianMechanism mechanism(epsilon, delta, sensitivity);
-  base::StatusOr<ConfidenceInterval> confidence_interval =
+  for (int i = 0; i < NUM_TESTS; i++){
+    double epsilon = epsilons[i];
+    double delta = deltas[i];
+    double sensitivity = sensitivities[i];
+    double level = levels[i];
+    double budget = budgets[i];
+    float true_lower_bound = true_bounds[i];
+    float true_upper_bound = -true_bounds[i];
+
+    GaussianMechanism mechanism(epsilon, delta, sensitivity);
+    base::StatusOr<ConfidenceInterval> confidence_interval =
       mechanism.NoiseConfidenceInterval(level, budget);
 
-  float true_lower_bound = -5.733;
-  float true_upper_bound = 5.733;
-
-  EXPECT_TRUE(confidence_interval.ok());
-  EXPECT_NEAR(confidence_interval.ValueOrDie().lower_bound(),
+    EXPECT_TRUE(confidence_interval.ok());
+    EXPECT_NEAR(confidence_interval.ValueOrDie().lower_bound(),
             true_lower_bound,0.001);
-  EXPECT_NEAR(confidence_interval.ValueOrDie().upper_bound(),
+    EXPECT_NEAR(confidence_interval.ValueOrDie().upper_bound(),
             true_upper_bound,0.001);
-  EXPECT_EQ(confidence_interval.ValueOrDie().confidence_level(), level);
-
-  // second test 
-  // stddev of 3.60742 for confidence interval calculation
-  epsilon = 1.0;
-  delta = 0.5;
-  sensitivity = 1.0;
-  level = .95;
-  budget = .5;
-
-  GaussianMechanism second_mechanism(epsilon, delta, sensitivity);
-  confidence_interval = second_mechanism.NoiseConfidenceInterval(level, budget);
-
-  true_lower_bound = -7.07;
-  true_upper_bound = 7.07;
-
-  EXPECT_TRUE(confidence_interval.ok());
-  EXPECT_NEAR(confidence_interval.ValueOrDie().lower_bound(),
-            true_lower_bound,0.001);
-  EXPECT_NEAR(confidence_interval.ValueOrDie().upper_bound(),
-            true_upper_bound,0.001);
-  EXPECT_EQ(confidence_interval.ValueOrDie().confidence_level(), level);
-
-  // third test 
-  // stddev of 0.367936 for confidence interval calculation
-  epsilon = 10.0;
-  delta = 0.5;
-  sensitivity = 1.0;
-  level = .95;
-  budget = .75;
-
-  GaussianMechanism third_mechanism(epsilon, delta, sensitivity);
-  confidence_interval = third_mechanism.NoiseConfidenceInterval(level, budget);
-
-  true_lower_bound = -0.7211;
-  true_upper_bound = 0.7211;
-
-  EXPECT_TRUE(confidence_interval.ok());
-  EXPECT_NEAR(confidence_interval.ValueOrDie().lower_bound(),
-            true_lower_bound,0.0001);
-  EXPECT_NEAR(confidence_interval.ValueOrDie().upper_bound(),
-            true_upper_bound,0.0001);
-  EXPECT_EQ(confidence_interval.ValueOrDie().confidence_level(), level);
-
+    EXPECT_EQ(confidence_interval.ValueOrDie().confidence_level(), level);
+  }
 
 }
 

--- a/cc/algorithms/util.cc
+++ b/cc/algorithms/util.cc
@@ -44,16 +44,18 @@ double DefaultEpsilon() { return std::log(3); }
 double GetNextPowerOfTwo(double n) { return pow(2.0, ceil(log2(n))); }
 
 
-float inverseErrorFunction(float x) {
+double inverseErrorFunction(double x) {
 
-  float LESS_THAN_FIVE_CONSTANTS[] = {2.81022636e-08f, 3.43273939e-07f, -3.5233877e-06f, 
-    -4.39150654e-06f, 0.00021858087f, -0.00125372503f, -0.00417768164f, 0.246640727f, 1.50140941f};
-  float GREATER_THAN_FIVE_CONSTANTS[] = {-0.000200214257, 0.000100950558f, 0.00134934322f, 
-    -0.00367342844f, 0.00573950773f, -0.0076224613f, 0.00943887047f, 1.00167406f, 2.83297682f};
+  double LESS_THAN_FIVE_CONSTANTS[] = {2.81022636*pow(10,-8), 3.43273939*pow(10,-7), 
+    -3.5233877*pow(10,-6), -4.39150654*pow(10,-6), 0.00021858087, -0.00125372503, 
+    -0.00417768164, 0.246640727, 1.50140941};
+  double GREATER_THAN_FIVE_CONSTANTS[] = {-0.000200214257, 
+    0.000100950558, 0.00134934322, -0.00367342844, 0.00573950773, 
+    -0.0076224613, 0.00943887047, 1.00167406, 2.83297682};
 
-  float constantArray[9];
-  float w = -std::log((1-x)*(1+x));
-  float ans = 0;
+  double constantArray[9];
+  double w = -std::log((1-x)*(1+x));
+  double ans = 0;
   
   if (std::abs(x) == 1){
     return x*std::numeric_limits<double>::infinity();
@@ -61,13 +63,18 @@ float inverseErrorFunction(float x) {
   
   if (w < 5){
     w = w-2.5;
-    std::copy(std::begin(LESS_THAN_FIVE_CONSTANTS),std::end(LESS_THAN_FIVE_CONSTANTS),std::begin(constantArray));
+    std::copy(std::begin(LESS_THAN_FIVE_CONSTANTS),
+      std::end(LESS_THAN_FIVE_CONSTANTS), 
+      std::begin(constantArray));
   } else{
     w = std::sqrt(w)-3;
-    std::copy(std::begin(GREATER_THAN_FIVE_CONSTANTS),std::end(GREATER_THAN_FIVE_CONSTANTS),std::begin(constantArray));
+    std::copy(std::begin(GREATER_THAN_FIVE_CONSTANTS),
+      std::end(GREATER_THAN_FIVE_CONSTANTS), 
+      std::begin(constantArray));
   } 
+
   for (int i = 0; i < 9; i++){
-    float coefficient = constantArray[i];
+    double coefficient = constantArray[i];
     ans = coefficient + ans*w;
   }
   

--- a/cc/algorithms/util.cc
+++ b/cc/algorithms/util.cc
@@ -43,6 +43,37 @@ double DefaultEpsilon() { return std::log(3); }
 
 double GetNextPowerOfTwo(double n) { return pow(2.0, ceil(log2(n))); }
 
+
+float inverseErrorFunction(float x) {
+
+  float LESS_THAN_FIVE_CONSTANTS[] = {2.81022636e-08f, 3.43273939e-07f, -3.5233877e-06f, 
+    -4.39150654e-06f, 0.00021858087f, -0.00125372503f, -0.00417768164f, 0.246640727f, 1.50140941f};
+  float GREATER_THAN_FIVE_CONSTANTS[] = {-0.000200214257, 0.000100950558f, 0.00134934322f, 
+    -0.00367342844f, 0.00573950773f, -0.0076224613f, 0.00943887047f, 1.00167406f, 2.83297682f};
+
+  float constantArray[9];
+  float w = -std::log((1-x)*(1+x));
+  float ans = 0;
+  
+  if (std::abs(x) == 1){
+    return x*std::numeric_limits<double>::infinity();
+  }
+  
+  if (w < 5){
+    w = w-2.5;
+    std::copy(std::begin(LESS_THAN_FIVE_CONSTANTS),std::end(LESS_THAN_FIVE_CONSTANTS),std::begin(constantArray));
+  } else{
+    w = std::sqrt(w)-3;
+    std::copy(std::begin(GREATER_THAN_FIVE_CONSTANTS),std::end(GREATER_THAN_FIVE_CONSTANTS),std::begin(constantArray));
+  } 
+  for (int i = 0; i < 9; i++){
+    float coefficient = constantArray[i];
+    ans = coefficient + ans*w;
+  }
+  
+  return ans * x;
+}
+
 base::StatusOr<double> Qnorm(double p, double mu, double sigma) {
   if (p <= 0.0 || p >= 1.0) {
     return base::InvalidArgumentError(

--- a/cc/algorithms/util.cc
+++ b/cc/algorithms/util.cc
@@ -18,6 +18,8 @@
 
 #include <cmath>
 
+#include <vector>
+
 #include "base/canonical_errors.h"
 
 namespace differential_privacy {
@@ -43,41 +45,39 @@ double DefaultEpsilon() { return std::log(3); }
 
 double GetNextPowerOfTwo(double n) { return pow(2.0, ceil(log2(n))); }
 
-
 double InverseErrorFunction(double x) {
-
-  double LESS_THAN_FIVE_CONSTANTS[] = {0.0000000281022636, 0.000000343273939, 
-    -0.0000035233877, -0.00000439150654, 0.00021858087, -0.00125372503, 
+  double LESS_THAN_FIVE_CONSTANTS[] = {0.0000000281022636, 0.000000343273939,
+    -0.0000035233877, -0.00000439150654, 0.00021858087, -0.00125372503,
     -0.00417768164, 0.246640727, 1.50140941};
-  double GREATER_THAN_FIVE_CONSTANTS[] = {-0.000200214257, 
-    0.000100950558, 0.00134934322, -0.00367342844, 0.00573950773, 
-    -0.0076224613, 0.00943887047, 1.00167406, 2.83297682};
+  double GREATER_THAN_FIVE_CONSTANTS[] = {-0.000200214257, 0.000100950558,
+    0.00134934322, -0.00367342844, 0.00573950773, -0.0076224613, 0.00943887047,
+    1.00167406, 2.83297682};
 
   double constantArray[9];
   double w = -std::log((1-x)*(1+x));
   double ans = 0;
-  
-  if (std::abs(x) == 1){
+
+  if (std::abs(x) == 1) {
     return x*std::numeric_limits<double>::infinity();
   }
-  
-  if (w < 5){
+
+  if (w < 5) {
     w = w-2.5;
     std::copy(std::begin(LESS_THAN_FIVE_CONSTANTS),
-      std::end(LESS_THAN_FIVE_CONSTANTS), 
+      std::end(LESS_THAN_FIVE_CONSTANTS),
       std::begin(constantArray));
-  } else{
+  } else {
     w = std::sqrt(w)-3;
     std::copy(std::begin(GREATER_THAN_FIVE_CONSTANTS),
-      std::end(GREATER_THAN_FIVE_CONSTANTS), 
+      std::end(GREATER_THAN_FIVE_CONSTANTS),
       std::begin(constantArray));
-  } 
+  }
 
-  for (int i = 0; i < 9; i++){
+  for (int i = 0; i < 9; i++) {
     double coefficient = constantArray[i];
     ans = coefficient + ans*w;
   }
-  
+
   return ans * x;
 }
 

--- a/cc/algorithms/util.cc
+++ b/cc/algorithms/util.cc
@@ -44,10 +44,10 @@ double DefaultEpsilon() { return std::log(3); }
 double GetNextPowerOfTwo(double n) { return pow(2.0, ceil(log2(n))); }
 
 
-double inverseErrorFunction(double x) {
+double InverseErrorFunction(double x) {
 
-  double LESS_THAN_FIVE_CONSTANTS[] = {2.81022636*pow(10,-8), 3.43273939*pow(10,-7), 
-    -3.5233877*pow(10,-6), -4.39150654*pow(10,-6), 0.00021858087, -0.00125372503, 
+  double LESS_THAN_FIVE_CONSTANTS[] = {0.0000000281022636, 0.000000343273939, 
+    -0.0000035233877, -0.00000439150654, 0.00021858087, -0.00125372503, 
     -0.00417768164, 0.246640727, 1.50140941};
   double GREATER_THAN_FIVE_CONSTANTS[] = {-0.000200214257, 
     0.000100950558, 0.00134934322, -0.00367342844, 0.00573950773, 

--- a/cc/algorithms/util.h
+++ b/cc/algorithms/util.h
@@ -57,7 +57,7 @@ double sign(double n);
 // Implementation based on Table 5 in Giles' paper 
 // on approximating the inverse of the error function 
 // (https://people.maths.ox.ac.uk/gilesm/files/gems_erfinv.pdf).
-float inverseErrorFunction(float x);
+double inverseErrorFunction(double x);
 
   
 

--- a/cc/algorithms/util.h
+++ b/cc/algorithms/util.h
@@ -53,6 +53,14 @@ double RoundToNearestMultiple(double n, double base);
 // Return 1.0 if n > 0, -1.0 if n < 0, and 0 if n == 0.
 double sign(double n);
 
+// Approximate the inverse of the error function.
+// Implementation based on Table 5 in Giles' paper 
+// on approximating the inverse of the error function 
+// (https://people.maths.ox.ac.uk/gilesm/files/gems_erfinv.pdf).
+float inverseErrorFunction(float x);
+
+  
+
 // Estimation of the inverse cdf of the normal distribution centered at mu with
 // standard deviation sigma, at probability p. Based on Abramowitz and Stegun
 // formula 26.2.23. The error of the estimation is bounded by 4.5 e-4. This

--- a/cc/algorithms/util.h
+++ b/cc/algorithms/util.h
@@ -54,12 +54,10 @@ double RoundToNearestMultiple(double n, double base);
 double sign(double n);
 
 // Approximate the inverse of the error function.
-// Implementation based on Table 5 in Giles' paper 
-// on approximating the inverse of the error function 
+// Implementation based on Table 5 in Giles' paper
+// on approximating the inverse of the error function
 // (https://people.maths.ox.ac.uk/gilesm/files/gems_erfinv.pdf).
 double InverseErrorFunction(double x);
-
-  
 
 // Estimation of the inverse cdf of the normal distribution centered at mu with
 // standard deviation sigma, at probability p. Based on Abramowitz and Stegun

--- a/cc/algorithms/util.h
+++ b/cc/algorithms/util.h
@@ -57,7 +57,7 @@ double sign(double n);
 // Implementation based on Table 5 in Giles' paper 
 // on approximating the inverse of the error function 
 // (https://people.maths.ox.ac.uk/gilesm/files/gems_erfinv.pdf).
-double inverseErrorFunction(double x);
+double InverseErrorFunction(double x);
 
   
 

--- a/cc/algorithms/util_test.cc
+++ b/cc/algorithms/util_test.cc
@@ -107,6 +107,11 @@ TEST(InverseErrorTest, ProperResults) {
   EXPECT_NEAR(inverseErrorFunction(0.5), 0.476, 0.001);
   EXPECT_NEAR(inverseErrorFunction(0.39), 0.360, 0.001);
   EXPECT_NEAR(inverseErrorFunction(0.0067), 0.0059, 0.001);
+
+  for (int i = 0; i < 100; i++){
+    double n = (double) rand()/RAND_MAX;
+    EXPECT_NEAR(std::erf(inverseErrorFunction(n)),n,0.0001);
+  }
 }
 
 TEST(InverseErrorTest, EdgeCases){

--- a/cc/algorithms/util_test.cc
+++ b/cc/algorithms/util_test.cc
@@ -101,27 +101,27 @@ TEST(NextPowerTest, ExactNegativePowers) {
 
 TEST(InverseErrorTest, ProperResults) {
   // true values are pre-calculated
-  EXPECT_NEAR(inverseErrorFunction(0.24), 0.216, 0.001);
-  EXPECT_NEAR(inverseErrorFunction(0.9999), 2.751, 0.001);
-  EXPECT_NEAR(inverseErrorFunction(0.0012), 0.001, 0.001);
-  EXPECT_NEAR(inverseErrorFunction(0.5), 0.476, 0.001);
-  EXPECT_NEAR(inverseErrorFunction(0.39), 0.360, 0.001);
-  EXPECT_NEAR(inverseErrorFunction(0.0067), 0.0059, 0.001);
+  EXPECT_NEAR(InverseErrorFunction(0.24), 0.216, 0.001);
+  EXPECT_NEAR(InverseErrorFunction(0.9999), 2.751, 0.001);
+  EXPECT_NEAR(InverseErrorFunction(0.0012), 0.001, 0.001);
+  EXPECT_NEAR(InverseErrorFunction(0.5), 0.476, 0.001);
+  EXPECT_NEAR(InverseErrorFunction(0.39), 0.360, 0.001);
+  EXPECT_NEAR(InverseErrorFunction(0.0067), 0.0059, 0.001);
 
   double max = 1;
   double min = -1;
   for (int i = 0; i < 1000; i++){
     double n = (max-min)*((double) rand()/RAND_MAX) + min;
-    EXPECT_NEAR(std::erf(inverseErrorFunction(n)),n,0.001);
+    EXPECT_NEAR(std::erf(InverseErrorFunction(n)),n,0.001);
   }
 }
 
 TEST(InverseErrorTest, EdgeCases){
-  EXPECT_EQ(inverseErrorFunction(-1), 
+  EXPECT_EQ(InverseErrorFunction(-1), 
     -1*std::numeric_limits<double>::infinity());
-  EXPECT_EQ(inverseErrorFunction(1), 
+  EXPECT_EQ(InverseErrorFunction(1), 
     std::numeric_limits<double>::infinity());
-  EXPECT_EQ(inverseErrorFunction(0), 0);
+  EXPECT_EQ(InverseErrorFunction(0), 0);
 }
 
 

--- a/cc/algorithms/util_test.cc
+++ b/cc/algorithms/util_test.cc
@@ -108,9 +108,11 @@ TEST(InverseErrorTest, ProperResults) {
   EXPECT_NEAR(inverseErrorFunction(0.39), 0.360, 0.001);
   EXPECT_NEAR(inverseErrorFunction(0.0067), 0.0059, 0.001);
 
-  for (int i = 0; i < 100; i++){
-    double n = (double) rand()/RAND_MAX;
-    EXPECT_NEAR(std::erf(inverseErrorFunction(n)),n,0.0001);
+  double max = 1;
+  double min = -1;
+  for (int i = 0; i < 1000; i++){
+    double n = (max-min)*((double) rand()/RAND_MAX) + min;
+    EXPECT_NEAR(std::erf(inverseErrorFunction(n)),n,0.001);
   }
 }
 

--- a/cc/algorithms/util_test.cc
+++ b/cc/algorithms/util_test.cc
@@ -110,16 +110,16 @@ TEST(InverseErrorTest, ProperResults) {
 
   double max = 1;
   double min = -1;
-  for (int i = 0; i < 1000; i++){
+  for (int i = 0; i < 1000; i++) {
     double n = (max-min)*((double) rand()/RAND_MAX) + min;
-    EXPECT_NEAR(std::erf(InverseErrorFunction(n)),n,0.001);
+    EXPECT_NEAR(std::erf(InverseErrorFunction(n)), n, 0.001);
   }
 }
 
-TEST(InverseErrorTest, EdgeCases){
-  EXPECT_EQ(InverseErrorFunction(-1), 
+TEST(InverseErrorTest, EdgeCases) {
+  EXPECT_EQ(InverseErrorFunction(-1),
     -1*std::numeric_limits<double>::infinity());
-  EXPECT_EQ(InverseErrorFunction(1), 
+  EXPECT_EQ(InverseErrorFunction(1),
     std::numeric_limits<double>::infinity());
   EXPECT_EQ(InverseErrorFunction(0), 0);
 }

--- a/cc/algorithms/util_test.cc
+++ b/cc/algorithms/util_test.cc
@@ -100,9 +100,13 @@ TEST(NextPowerTest, ExactNegativePowers) {
 }
 
 TEST(InverseErrorTest, ProperResults) {
+  // true values are pre-calculated
   EXPECT_NEAR(inverseErrorFunction(0.24), 0.216, 0.001);
   EXPECT_NEAR(inverseErrorFunction(0.9999), 2.751, 0.001);
   EXPECT_NEAR(inverseErrorFunction(0.0012), 0.001, 0.001);
+  EXPECT_NEAR(inverseErrorFunction(0.5), 0.476, 0.001);
+  EXPECT_NEAR(inverseErrorFunction(0.39), 0.360, 0.001);
+  EXPECT_NEAR(inverseErrorFunction(0.0067), 0.0059, 0.001);
 }
 
 TEST(InverseErrorTest, EdgeCases){

--- a/cc/algorithms/util_test.cc
+++ b/cc/algorithms/util_test.cc
@@ -99,6 +99,21 @@ TEST(NextPowerTest, ExactNegativePowers) {
   EXPECT_NEAR(GetNextPowerOfTwo(0.125), 0.125, kTolerance);
 }
 
+TEST(InverseErrorTest, ProperResults) {
+  EXPECT_NEAR(inverseErrorFunction(0.24), 0.216, 0.001);
+  EXPECT_NEAR(inverseErrorFunction(0.9999), 2.751, 0.001);
+  EXPECT_NEAR(inverseErrorFunction(0.0012), 0.001, 0.001);
+}
+
+TEST(InverseErrorTest, EdgeCases){
+  EXPECT_EQ(inverseErrorFunction(-1), 
+    -1*std::numeric_limits<double>::infinity());
+  EXPECT_EQ(inverseErrorFunction(1), 
+    std::numeric_limits<double>::infinity());
+  EXPECT_EQ(inverseErrorFunction(0), 0);
+}
+
+
 TEST(RoundTest, PositiveNoTies) {
   EXPECT_NEAR(RoundToNearestMultiple(4.9, 2.0), 4.0, kTolerance);
   EXPECT_NEAR(RoundToNearestMultiple(5.1, 2.0), 6.0, kTolerance);


### PR DESCRIPTION
Implemented method to calculate the noise confidence interval for Gaussian noise, which also involved adding a function that approximates the inverse error function. Also added tests for those changes.