### PR TITLE
Update go.mod reference to beam.

### DIFF
--- a/privacy-on-beam/go.mod
+++ b/privacy-on-beam/go.mod
@@ -3,9 +3,9 @@ module github.com/google/differential-privacy/privacy-on-beam
 go 1.14
 
 require (
-github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
-github.com/google/go-cmp v0.4.2-0.20200609072101-23a2b5646fe0
-github.com/apache/beam v2.22.0
-google.golang.org/protobuf v1.24.1-0.20200612063355-beaa55256c57
-gonum.org/v1/plot v0.7.0
+	github.com/apache/beam v2.22.0+incompatible
+	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
+	github.com/google/go-cmp v0.4.2-0.20200609072101-23a2b5646fe0
+	gonum.org/v1/plot v0.7.0
+	google.golang.org/protobuf v1.24.1-0.20200612063355-beaa55256c57
 )


### PR DESCRIPTION
This fixes the version reference to apache/beam which is not a "v2" style go package, closing #24.  It also apply standard Go formatting to go.mod.