### PR TITLE
Java: Add confidence interval interface

### DIFF
--- a/java/main/com/google/privacy/differentialprivacy/ConfidenceInterval.java
+++ b/java/main/com/google/privacy/differentialprivacy/ConfidenceInterval.java
@@ -1,0 +1,18 @@
+package com.google.privacy.differentialprivacy;
+
+import com.google.auto.value.AutoValue;
+
+/**
+ * Valued-typed class that holds real bounds for the confidence interval.
+ */
+@AutoValue
+public abstract class ConfidenceInterval{
+
+    public abstract double getLowerBound();
+
+    public abstract double getUpperBound();
+
+    public static ConfidenceInterval create(double lowerBound, double upperBound){
+        return new AutoValue_ConfidenceInterval(lowerBound, upperBound);
+    }
+}

--- a/java/main/com/google/privacy/differentialprivacy/ConfidenceInterval.java
+++ b/java/main/com/google/privacy/differentialprivacy/ConfidenceInterval.java
@@ -7,7 +7,6 @@ import com.google.auto.value.AutoValue;
  */
 @AutoValue
 public abstract class ConfidenceInterval{
-
     public abstract double getLowerBound();
 
     public abstract double getUpperBound();

--- a/java/main/com/google/privacy/differentialprivacy/ConfidenceInterval.java
+++ b/java/main/com/google/privacy/differentialprivacy/ConfidenceInterval.java
@@ -2,16 +2,14 @@ package com.google.privacy.differentialprivacy;
 
 import com.google.auto.value.AutoValue;
 
-/**
- * Stores the upper and lower bounds of a confidence interval.
- */
+/** Stores the upper and lower bounds of a confidence interval. */
 @AutoValue
-public abstract class ConfidenceInterval{
-    public abstract double lowerBound();
+public abstract class ConfidenceInterval {
+  public abstract double lowerBound();
 
-    public abstract double upperBound();
+  public abstract double upperBound();
 
-    public static ConfidenceInterval create(double lowerBound, double upperBound){
-        return new AutoValue_ConfidenceInterval(lowerBound, upperBound);
-    }
+  public static ConfidenceInterval create(double lowerBound, double upperBound) {
+    return new AutoValue_ConfidenceInterval(lowerBound, upperBound);
+  }
 }

--- a/java/main/com/google/privacy/differentialprivacy/ConfidenceInterval.java
+++ b/java/main/com/google/privacy/differentialprivacy/ConfidenceInterval.java
@@ -7,9 +7,9 @@ import com.google.auto.value.AutoValue;
  */
 @AutoValue
 public abstract class ConfidenceInterval{
-    public abstract double getLowerBound();
+    public abstract double lowerBound();
 
-    public abstract double getUpperBound();
+    public abstract double upperBound();
 
     public static ConfidenceInterval create(double lowerBound, double upperBound){
         return new AutoValue_ConfidenceInterval(lowerBound, upperBound);

--- a/java/main/com/google/privacy/differentialprivacy/ConfidenceInterval.java
+++ b/java/main/com/google/privacy/differentialprivacy/ConfidenceInterval.java
@@ -3,7 +3,7 @@ package com.google.privacy.differentialprivacy;
 import com.google.auto.value.AutoValue;
 
 /**
- * Valued-typed class that holds real bounds for the confidence interval.
+ * Stores the upper and lower bounds of a confidence interval.
  */
 @AutoValue
 public abstract class ConfidenceInterval{

--- a/java/main/com/google/privacy/differentialprivacy/DpPreconditions.java
+++ b/java/main/com/google/privacy/differentialprivacy/DpPreconditions.java
@@ -148,8 +148,8 @@ public class DpPreconditions {
 
   static void checkConfidenceLevel(double confidenceLevel){
     checkArgument(
-            0 <= confidenceLevel && confidenceLevel <= 1 && !Double.isNaN(confidenceLevel),
-            "confidenceLevel is %s, should be between 0 and 1 (and cannot be NaN)",
+            0 < confidenceLevel && confidenceLevel < 1 && !Double.isNaN(confidenceLevel),
+            "confidenceLevel is %s, should be between 0 and 1 (exclusive and cannot be NaN)",
             confidenceLevel);
   }
 }

--- a/java/main/com/google/privacy/differentialprivacy/DpPreconditions.java
+++ b/java/main/com/google/privacy/differentialprivacy/DpPreconditions.java
@@ -55,7 +55,8 @@ public class DpPreconditions {
   static void checkSensitivities(int l0Sensitivity, double lInfSensitivity) {
     checkL0Sensitivity(l0Sensitivity);
     checkArgument(
-        lInfSensitivity > 0, "lInfSensitivity must be > 0. Provided value: %s", lInfSensitivity);
+        lInfSensitivity > 0 && !Double.isInfinite(lInfSensitivity),
+            "lInfSensitivity must be > 0 (and cannot be Infinity). Provided value: %s", lInfSensitivity);
   }
 
   static void checkL0Sensitivity(int l0Sensitivity) {
@@ -65,7 +66,8 @@ public class DpPreconditions {
 
   static void checkL1Sensitivity(double l1Sensitivity) {
     checkArgument(
-        l1Sensitivity > 0, "l1Sensitivity must be > 0. Provided value: %s", l1Sensitivity);
+        l1Sensitivity > 0 && !Double.isInfinite(l1Sensitivity),
+            "l1Sensitivity must be > 0 (and cannot be Infinity). Provided value: %s", l1Sensitivity);
   }
 
   static void checkMaxPartitionsContributed(int maxPartitionsContributed) {

--- a/java/main/com/google/privacy/differentialprivacy/DpPreconditions.java
+++ b/java/main/com/google/privacy/differentialprivacy/DpPreconditions.java
@@ -143,4 +143,11 @@ public class DpPreconditions {
     checkArgument(Objects.equals(type1, type2),
         "Failed to merge: unequal mechanism types. type1 = %s, type2 = %s", type1, type2);
   }
+
+  static void checkConfidenceLevel(double confidenceLevel){
+    checkArgument(
+            confidenceLevel < 0 || confidenceLevel > 1 || Double.isNaN(confidenceLevel),
+            "confidenceLevel is %s, should be between 0 and 1 (and cannot be NaN)",
+            confidenceLevel);
+  }
 }

--- a/java/main/com/google/privacy/differentialprivacy/DpPreconditions.java
+++ b/java/main/com/google/privacy/differentialprivacy/DpPreconditions.java
@@ -146,7 +146,7 @@ public class DpPreconditions {
 
   static void checkConfidenceLevel(double confidenceLevel){
     checkArgument(
-            confidenceLevel < 0 || confidenceLevel > 1 || Double.isNaN(confidenceLevel),
+            0 <= confidenceLevel && confidenceLevel <= 1 && !Double.isNaN(confidenceLevel),
             "confidenceLevel is %s, should be between 0 and 1 (and cannot be NaN)",
             confidenceLevel);
   }

--- a/java/main/com/google/privacy/differentialprivacy/DpPreconditions.java
+++ b/java/main/com/google/privacy/differentialprivacy/DpPreconditions.java
@@ -56,7 +56,8 @@ public class DpPreconditions {
     checkL0Sensitivity(l0Sensitivity);
     checkArgument(
         lInfSensitivity > 0 && !Double.isInfinite(lInfSensitivity),
-            "lInfSensitivity must be > 0 (and cannot be Infinity). Provided value: %s", lInfSensitivity);
+        "lInfSensitivity must be > 0 (and cannot be Infinity). Provided value: %s",
+        lInfSensitivity);
   }
 
   static void checkL0Sensitivity(int l0Sensitivity) {
@@ -67,7 +68,8 @@ public class DpPreconditions {
   static void checkL1Sensitivity(double l1Sensitivity) {
     checkArgument(
         l1Sensitivity > 0 && !Double.isInfinite(l1Sensitivity),
-            "l1Sensitivity must be > 0 (and cannot be Infinity). Provided value: %s", l1Sensitivity);
+        "l1Sensitivity must be > 0 (and cannot be Infinity). Provided value: %s",
+        l1Sensitivity);
   }
 
   static void checkMaxPartitionsContributed(int maxPartitionsContributed) {
@@ -146,10 +148,11 @@ public class DpPreconditions {
         "Failed to merge: unequal mechanism types. type1 = %s, type2 = %s", type1, type2);
   }
 
-  static void checkConfidenceLevel(double confidenceLevel){
+  static void checkConfidenceLevel(double confidenceLevel) {
     checkArgument(
-            0 < confidenceLevel && confidenceLevel < 1 && !Double.isNaN(confidenceLevel),
-            "confidenceLevel is %s, should be between 0 and 1 (exclusive and cannot be NaN)",
-            confidenceLevel);
+        0 < confidenceLevel && confidenceLevel < 1 && !Double.isNaN(confidenceLevel),
+        "confidenceLevel should be between 0 and 1 (exclusive and cannot be NaN). "
+            + "Provided value: %s",
+        confidenceLevel);
   }
 }

--- a/java/main/com/google/privacy/differentialprivacy/GaussianNoise.java
+++ b/java/main/com/google/privacy/differentialprivacy/GaussianNoise.java
@@ -115,12 +115,12 @@ public class GaussianNoise implements Noise {
   }
 
   /**
-   * Returns {@link ConfidenceInterval} object with the given {@code confidenceLevel},
-   * using {@code noisedValue}, L_0 and L_inf sensitivities,
-   * and {@code epsilon} and {@code delta} for Gaussian distribution.
+   * Computes a confidence interval that contains the raw value {@code x} passed to
+   * {@link #addNoise(double, int, double, double, Double)} with a probability greater
+   * or equal to {@code confidenceLevel} based on the specified {@noisedValue} and noise parameters.
    */
   @Override
-  public ConfidenceInterval getConfidenceInterval(
+  public ConfidenceInterval computeConfidenceInterval(
           double noisedValue, int l0Sensitivity, double lInfSensitivity,
           double epsilon, Double delta, double confidenceLevel){
     // TODO: Implement confidence interval computation.
@@ -128,13 +128,13 @@ public class GaussianNoise implements Noise {
   }
 
   /**
-   * Returns {@link ConfidenceInterval} object with integer bounds for the given {@code confidenceLevel},
-   * using integer {@code noisedValue}, L_0 and L_inf sensitivities,
-   * and {@code epsilon} and {@code delta} for Gaussian distribution.
+   * Computes a confidence interval that contains the raw value integer {@code x} passed to
+   * {@link #addNoise(long, int, long, double, Double)} with a probability greater
+   * or equal to {@code confidenceLevel} based on the specified {@noisedValue} and noise parameters.
    */
   @Override
-  public ConfidenceInterval getConfidenceInterval(
-          int noisedValue, int l0Sensitivity, long lInfSensitivity,
+  public ConfidenceInterval computeConfidenceInterval(
+          long noisedValue, int l0Sensitivity, long lInfSensitivity,
           double epsilon, Double delta, double confidenceLevel){
     // TODO: Implement confidence interval computation.
     return null;

--- a/java/main/com/google/privacy/differentialprivacy/GaussianNoise.java
+++ b/java/main/com/google/privacy/differentialprivacy/GaussianNoise.java
@@ -127,6 +127,19 @@ public class GaussianNoise implements Noise {
     return null;
   }
 
+  /**
+   * Returns {@link ConfidenceInterval} object with integer bounds for the given {@code confidenceLevel},
+   * using integer {@code noisedValue}, L_0 and L_inf sensitivities,
+   * and {@code epsilon} and {@code delta} for Gaussian distribution.
+   */
+  @Override
+  public ConfidenceInterval getConfidenceInterval(
+          int noisedValue, int l0Sensitivity, long lInfSensitivity,
+          double epsilon, Double delta, double confidenceLevel){
+    // TODO: Implement confidence interval computation.
+    return null;
+  }
+
   private void checkParameters(
       int l0Sensitivity, double lInfSensitivity, double epsilon, Double delta) {
     DpPreconditions.checkSensitivities(l0Sensitivity, lInfSensitivity);

--- a/java/main/com/google/privacy/differentialprivacy/GaussianNoise.java
+++ b/java/main/com/google/privacy/differentialprivacy/GaussianNoise.java
@@ -128,7 +128,7 @@ public class GaussianNoise implements Noise {
       Double delta,
       double confidenceLevel) {
     // TODO: Implement confidence interval computation.
-    return null;
+    throw new UnsupportedOperationException("Not implemented yet.");
   }
 
   /**
@@ -145,7 +145,7 @@ public class GaussianNoise implements Noise {
       Double delta,
       double confidenceLevel) {
     // TODO: Implement confidence interval computation.
-    return null;
+    throw new UnsupportedOperationException("Not implemented yet.");
   }
 
   private void checkParameters(

--- a/java/main/com/google/privacy/differentialprivacy/GaussianNoise.java
+++ b/java/main/com/google/privacy/differentialprivacy/GaussianNoise.java
@@ -114,6 +114,19 @@ public class GaussianNoise implements Noise {
     return MechanismType.GAUSSIAN;
   }
 
+  /**
+   * Returns {@link ConfidenceInterval} object with the given {@code confidenceLevel},
+   * using {@code noisedValue}, L_0 and L_inf sensitivities,
+   * and {@code epsilon} and {@code delta} for Gaussian distribution.
+   */
+  @Override
+  public ConfidenceInterval getConfidenceInterval(
+          double noisedValue, int l0Sensitivity, double lInfSensitivity,
+          double epsilon, Double delta, double confidenceLevel){
+    // TODO: Implement confidence interval computation.
+    return null;
+  }
+
   private void checkParameters(
       int l0Sensitivity, double lInfSensitivity, double epsilon, Double delta) {
     DpPreconditions.checkSensitivities(l0Sensitivity, lInfSensitivity);

--- a/java/main/com/google/privacy/differentialprivacy/GaussianNoise.java
+++ b/java/main/com/google/privacy/differentialprivacy/GaussianNoise.java
@@ -116,12 +116,12 @@ public class GaussianNoise implements Noise {
 
   /**
    * Computes a confidence interval that contains the raw value {@code x} passed to
-   * {@link #addNoise(double, int, double, double, Double)} with a probability greater
-   * or equal to {@code confidenceLevel} based on the specified {@noisedValue} and noise parameters.
+   * {@link #addNoise(double, int, double, double, Double)} with a probability equal
+   * to {@code confidenceLevel} based on the specified {@code noisedX} and noise parameters.
    */
   @Override
   public ConfidenceInterval computeConfidenceInterval(
-          double noisedValue, int l0Sensitivity, double lInfSensitivity,
+          double noisedX, int l0Sensitivity, double lInfSensitivity,
           double epsilon, Double delta, double confidenceLevel){
     // TODO: Implement confidence interval computation.
     return null;
@@ -130,11 +130,11 @@ public class GaussianNoise implements Noise {
   /**
    * Computes a confidence interval that contains the raw value integer {@code x} passed to
    * {@link #addNoise(long, int, long, double, Double)} with a probability greater
-   * or equal to {@code confidenceLevel} based on the specified {@noisedValue} and noise parameters.
+   * or equal to {@code confidenceLevel} based on the specified {@code noisedX} and noise parameters.
    */
   @Override
   public ConfidenceInterval computeConfidenceInterval(
-          long noisedValue, int l0Sensitivity, long lInfSensitivity,
+          long noisedX, int l0Sensitivity, long lInfSensitivity,
           double epsilon, Double delta, double confidenceLevel){
     // TODO: Implement confidence interval computation.
     return null;

--- a/java/main/com/google/privacy/differentialprivacy/GaussianNoise.java
+++ b/java/main/com/google/privacy/differentialprivacy/GaussianNoise.java
@@ -115,27 +115,35 @@ public class GaussianNoise implements Noise {
   }
 
   /**
-   * Computes a confidence interval that contains the raw value {@code x} passed to
-   * {@link #addNoise(double, int, double, double, Double)} with a probability equal
-   * to {@code confidenceLevel} based on the specified {@code noisedX} and noise parameters.
+   * Computes a confidence interval that contains the raw value {@code x} passed to {@link
+   * #addNoise(double, int, double, double, Double)} with a probability equal to {@code
+   * confidenceLevel} based on the specified {@code noisedX} and noise parameters.
    */
   @Override
   public ConfidenceInterval computeConfidenceInterval(
-          double noisedX, int l0Sensitivity, double lInfSensitivity,
-          double epsilon, Double delta, double confidenceLevel){
+      double noisedX,
+      int l0Sensitivity,
+      double lInfSensitivity,
+      double epsilon,
+      Double delta,
+      double confidenceLevel) {
     // TODO: Implement confidence interval computation.
     return null;
   }
 
   /**
-   * Computes a confidence interval that contains the raw value integer {@code x} passed to
-   * {@link #addNoise(long, int, long, double, Double)} with a probability greater
-   * or equal to {@code confidenceLevel} based on the specified {@code noisedX} and noise parameters.
+   * Computes a confidence interval that contains the raw value integer {@code x} passed to {@link
+   * #addNoise(long, int, long, double, Double)} with a probability greater or equal to {@code
+   * confidenceLevel} based on the specified {@code noisedX} and noise parameters.
    */
   @Override
   public ConfidenceInterval computeConfidenceInterval(
-          long noisedX, int l0Sensitivity, long lInfSensitivity,
-          double epsilon, Double delta, double confidenceLevel){
+      long noisedX,
+      int l0Sensitivity,
+      long lInfSensitivity,
+      double epsilon,
+      Double delta,
+      double confidenceLevel) {
     // TODO: Implement confidence interval computation.
     return null;
   }

--- a/java/main/com/google/privacy/differentialprivacy/LaplaceNoise.java
+++ b/java/main/com/google/privacy/differentialprivacy/LaplaceNoise.java
@@ -133,7 +133,7 @@ public class LaplaceNoise implements Noise {
       @Nullable Double delta,
       double confidenceLevel) {
     // TODO: Implement confidence interval computation.
-    return null;
+    throw new UnsupportedOperationException("Not implemented yet.");
   }
 
   /**
@@ -151,7 +151,7 @@ public class LaplaceNoise implements Noise {
       @Nullable Double delta,
       double confidenceLevel) {
     // TODO: Implement confidence interval computation.
-    return null;
+    throw new UnsupportedOperationException("Not implemented yet.");
   }
 
   private void checkParameters(double l1Sensitivity, double epsilon, @Nullable Double delta) {

--- a/java/main/com/google/privacy/differentialprivacy/LaplaceNoise.java
+++ b/java/main/com/google/privacy/differentialprivacy/LaplaceNoise.java
@@ -118,6 +118,21 @@ public class LaplaceNoise implements Noise {
     return Math.round(addNoise((double) x, l1Sensitivity, epsilon, delta));
   }
 
+  /**
+   * Returns {@link ConfidenceInterval} object with the given {@code confidenceLevel},
+   * using {@code noisedValue}, L_0 and L_inf sensitivities,
+   * and {@code epsilon} and {@code delta} for Laplace distribution.
+   * Note that {@code delta} must be set to {@code null} because it does not parameterize Laplace
+   * noise. Moreover, {@code epsilon} must be at least 2^-50.
+   */
+  @Override
+  public ConfidenceInterval getConfidenceInterval(
+          double noisedValue, int l0Sensitivity, double lInfSensitivity,
+          double epsilon, @Nullable Double delta, double confidenceLevel){
+    // TODO: Implement confidence interval computation.
+    return null;
+  }
+
   private void checkParameters(double l1Sensitivity, double epsilon, @Nullable Double delta) {
     DpPreconditions.checkEpsilon(epsilon);
     DpPreconditions.checkNoiseDelta(delta, this);

--- a/java/main/com/google/privacy/differentialprivacy/LaplaceNoise.java
+++ b/java/main/com/google/privacy/differentialprivacy/LaplaceNoise.java
@@ -119,14 +119,14 @@ public class LaplaceNoise implements Noise {
   }
 
   /**
-   * Returns {@link ConfidenceInterval} object with the given {@code confidenceLevel},
-   * using {@code noisedValue}, L_0 and L_inf sensitivities,
-   * and {@code epsilon} and {@code delta} for Laplace distribution.
+   * Computes a confidence interval that contains the raw value {@code x} passed to
+   * {@link #addNoise(double, int, double, double, Double)} with a probability greater
+   * or equal to {@code confidenceLevel} based on the specified {@noisedValue} and noise parameters.
    * Note that {@code delta} must be set to {@code null} because it does not parameterize Laplace
    * noise. Moreover, {@code epsilon} must be at least 2^-50.
    */
   @Override
-  public ConfidenceInterval getConfidenceInterval(
+  public ConfidenceInterval computeConfidenceInterval(
           double noisedValue, int l0Sensitivity, double lInfSensitivity,
           double epsilon, @Nullable Double delta, double confidenceLevel){
     // TODO: Implement confidence interval computation.
@@ -134,15 +134,15 @@ public class LaplaceNoise implements Noise {
   }
 
   /**
-   * Returns {@link ConfidenceInterval} object with integer bounds for the given {@code confidenceLevel},
-   * using integer {@code noisedValue}, L_0 and L_inf sensitivities,
-   * and {@code epsilon} and {@code delta} for Laplace distribution.
+   * Computes a confidence interval that contains the raw value integer {@code x} passed to
+   * {@link #addNoise(long, int, long, double, Double)} with a probability greater
+   * or equal to {@code confidenceLevel} based on the specified {@noisedValue} and noise parameters.
    * Note that {@code delta} must be set to {@code null} because it does not parameterize Laplace
    * noise. Moreover, {@code epsilon} must be at least 2^-50.
    */
   @Override
-  public ConfidenceInterval getConfidenceInterval(
-          int noisedValue, int l0Sensitivity, long lInfSensitivity,
+  public ConfidenceInterval computeConfidenceInterval(
+          long noisedValue, int l0Sensitivity, long lInfSensitivity,
           double epsilon, @Nullable Double delta, double confidenceLevel){
     // TODO: Implement confidence interval computation.
     return null;

--- a/java/main/com/google/privacy/differentialprivacy/LaplaceNoise.java
+++ b/java/main/com/google/privacy/differentialprivacy/LaplaceNoise.java
@@ -133,6 +133,21 @@ public class LaplaceNoise implements Noise {
     return null;
   }
 
+  /**
+   * Returns {@link ConfidenceInterval} object with integer bounds for the given {@code confidenceLevel},
+   * using integer {@code noisedValue}, L_0 and L_inf sensitivities,
+   * and {@code epsilon} and {@code delta} for Laplace distribution.
+   * Note that {@code delta} must be set to {@code null} because it does not parameterize Laplace
+   * noise. Moreover, {@code epsilon} must be at least 2^-50.
+   */
+  @Override
+  public ConfidenceInterval getConfidenceInterval(
+          int noisedValue, int l0Sensitivity, long lInfSensitivity,
+          double epsilon, @Nullable Double delta, double confidenceLevel){
+    // TODO: Implement confidence interval computation.
+    return null;
+  }
+
   private void checkParameters(double l1Sensitivity, double epsilon, @Nullable Double delta) {
     DpPreconditions.checkEpsilon(epsilon);
     DpPreconditions.checkNoiseDelta(delta, this);

--- a/java/main/com/google/privacy/differentialprivacy/LaplaceNoise.java
+++ b/java/main/com/google/privacy/differentialprivacy/LaplaceNoise.java
@@ -120,14 +120,14 @@ public class LaplaceNoise implements Noise {
 
   /**
    * Computes a confidence interval that contains the raw value {@code x} passed to
-   * {@link #addNoise(double, int, double, double, Double)} with a probability greater
-   * or equal to {@code confidenceLevel} based on the specified {@noisedValue} and noise parameters.
+   * {@link #addNoise(double, int, double, double, Double)} with a probability equal
+   * to {@code confidenceLevel} based on the specified {@code noisedX} and noise parameters.
    * Note that {@code delta} must be set to {@code null} because it does not parameterize Laplace
-   * noise. Moreover, {@code epsilon} must be at least 2^-50.
+   * noise.
    */
   @Override
   public ConfidenceInterval computeConfidenceInterval(
-          double noisedValue, int l0Sensitivity, double lInfSensitivity,
+          double noisedX, int l0Sensitivity, double lInfSensitivity,
           double epsilon, @Nullable Double delta, double confidenceLevel){
     // TODO: Implement confidence interval computation.
     return null;
@@ -136,13 +136,13 @@ public class LaplaceNoise implements Noise {
   /**
    * Computes a confidence interval that contains the raw value integer {@code x} passed to
    * {@link #addNoise(long, int, long, double, Double)} with a probability greater
-   * or equal to {@code confidenceLevel} based on the specified {@noisedValue} and noise parameters.
+   * or equal to {@code confidenceLevel} based on the specified {@code noisedX} and noise parameters.
    * Note that {@code delta} must be set to {@code null} because it does not parameterize Laplace
-   * noise. Moreover, {@code epsilon} must be at least 2^-50.
+   * noise.
    */
   @Override
   public ConfidenceInterval computeConfidenceInterval(
-          long noisedValue, int l0Sensitivity, long lInfSensitivity,
+          long noisedX, int l0Sensitivity, long lInfSensitivity,
           double epsilon, @Nullable Double delta, double confidenceLevel){
     // TODO: Implement confidence interval computation.
     return null;

--- a/java/main/com/google/privacy/differentialprivacy/LaplaceNoise.java
+++ b/java/main/com/google/privacy/differentialprivacy/LaplaceNoise.java
@@ -119,31 +119,37 @@ public class LaplaceNoise implements Noise {
   }
 
   /**
-   * Computes a confidence interval that contains the raw value {@code x} passed to
-   * {@link #addNoise(double, int, double, double, Double)} with a probability equal
-   * to {@code confidenceLevel} based on the specified {@code noisedX} and noise parameters.
-   * Note that {@code delta} must be set to {@code null} because it does not parameterize Laplace
-   * noise.
+   * Computes a confidence interval that contains the raw value {@code x} passed to {@link
+   * #addNoise(double, int, double, double, Double)} with a probability equal to {@code
+   * confidenceLevel} based on the specified {@code noisedX} and noise parameters. Note that {@code
+   * delta} must be set to {@code null} because it does not parameterize Laplace noise.
    */
   @Override
   public ConfidenceInterval computeConfidenceInterval(
-          double noisedX, int l0Sensitivity, double lInfSensitivity,
-          double epsilon, @Nullable Double delta, double confidenceLevel){
+      double noisedX,
+      int l0Sensitivity,
+      double lInfSensitivity,
+      double epsilon,
+      @Nullable Double delta,
+      double confidenceLevel) {
     // TODO: Implement confidence interval computation.
     return null;
   }
 
   /**
-   * Computes a confidence interval that contains the raw value integer {@code x} passed to
-   * {@link #addNoise(long, int, long, double, Double)} with a probability greater
-   * or equal to {@code confidenceLevel} based on the specified {@code noisedX} and noise parameters.
-   * Note that {@code delta} must be set to {@code null} because it does not parameterize Laplace
-   * noise.
+   * Computes a confidence interval that contains the raw value integer {@code x} passed to {@link
+   * #addNoise(long, int, long, double, Double)} with a probability greater or equal to {@code
+   * confidenceLevel} based on the specified {@code noisedX} and noise parameters. Note that {@code
+   * delta} must be set to {@code null} because it does not parameterize Laplace noise.
    */
   @Override
   public ConfidenceInterval computeConfidenceInterval(
-          long noisedX, int l0Sensitivity, long lInfSensitivity,
-          double epsilon, @Nullable Double delta, double confidenceLevel){
+      long noisedX,
+      int l0Sensitivity,
+      long lInfSensitivity,
+      double epsilon,
+      @Nullable Double delta,
+      double confidenceLevel) {
     // TODO: Implement confidence interval computation.
     return null;
   }

--- a/java/main/com/google/privacy/differentialprivacy/Noise.java
+++ b/java/main/com/google/privacy/differentialprivacy/Noise.java
@@ -31,6 +31,10 @@ public interface Noise {
   long addNoise(
       long x, int l0Sensitivity, long lInfSensitivity, double epsilon, @Nullable Double delta);
 
+  ConfidenceInterval getConfidenceInterval(
+          double noisedValue, int l0Sensitivity, double lInfSensitivity,
+          double epsilon, @Nullable Double delta, double confidenceLevel);
+
   MechanismType getMechanismType();
 
   static double getL1Sensitivity(int l0Sensitivity, double lInfSensitivity) {

--- a/java/main/com/google/privacy/differentialprivacy/Noise.java
+++ b/java/main/com/google/privacy/differentialprivacy/Noise.java
@@ -31,12 +31,12 @@ public interface Noise {
   long addNoise(
       long x, int l0Sensitivity, long lInfSensitivity, double epsilon, @Nullable Double delta);
 
-  ConfidenceInterval getConfidenceInterval(
+  ConfidenceInterval computeConfidenceInterval(
           double noisedValue, int l0Sensitivity, double lInfSensitivity,
           double epsilon, @Nullable Double delta, double confidenceLevel);
 
-  ConfidenceInterval getConfidenceInterval(
-          int noisedValue, int l0Sensitivity, long lInfSensitivity,
+  ConfidenceInterval computeConfidenceInterval(
+          long noisedValue, int l0Sensitivity, long lInfSensitivity,
           double epsilon, @Nullable Double delta, double confidenceLevel);
 
   MechanismType getMechanismType();

--- a/java/main/com/google/privacy/differentialprivacy/Noise.java
+++ b/java/main/com/google/privacy/differentialprivacy/Noise.java
@@ -35,6 +35,10 @@ public interface Noise {
           double noisedValue, int l0Sensitivity, double lInfSensitivity,
           double epsilon, @Nullable Double delta, double confidenceLevel);
 
+  ConfidenceInterval getConfidenceInterval(
+          int noisedValue, int l0Sensitivity, long lInfSensitivity,
+          double epsilon, @Nullable Double delta, double confidenceLevel);
+
   MechanismType getMechanismType();
 
   static double getL1Sensitivity(int l0Sensitivity, double lInfSensitivity) {

--- a/java/main/com/google/privacy/differentialprivacy/Noise.java
+++ b/java/main/com/google/privacy/differentialprivacy/Noise.java
@@ -32,12 +32,20 @@ public interface Noise {
       long x, int l0Sensitivity, long lInfSensitivity, double epsilon, @Nullable Double delta);
 
   ConfidenceInterval computeConfidenceInterval(
-          double noisedX, int l0Sensitivity, double lInfSensitivity,
-          double epsilon, @Nullable Double delta, double confidenceLevel);
+      double noisedX,
+      int l0Sensitivity,
+      double lInfSensitivity,
+      double epsilon,
+      @Nullable Double delta,
+      double confidenceLevel);
 
   ConfidenceInterval computeConfidenceInterval(
-          long noisedX, int l0Sensitivity, long lInfSensitivity,
-          double epsilon, @Nullable Double delta, double confidenceLevel);
+      long noisedX,
+      int l0Sensitivity,
+      long lInfSensitivity,
+      double epsilon,
+      @Nullable Double delta,
+      double confidenceLevel);
 
   MechanismType getMechanismType();
 

--- a/java/main/com/google/privacy/differentialprivacy/Noise.java
+++ b/java/main/com/google/privacy/differentialprivacy/Noise.java
@@ -32,11 +32,11 @@ public interface Noise {
       long x, int l0Sensitivity, long lInfSensitivity, double epsilon, @Nullable Double delta);
 
   ConfidenceInterval computeConfidenceInterval(
-          double noisedValue, int l0Sensitivity, double lInfSensitivity,
+          double noisedX, int l0Sensitivity, double lInfSensitivity,
           double epsilon, @Nullable Double delta, double confidenceLevel);
 
   ConfidenceInterval computeConfidenceInterval(
-          long noisedValue, int l0Sensitivity, long lInfSensitivity,
+          long noisedX, int l0Sensitivity, long lInfSensitivity,
           double epsilon, @Nullable Double delta, double confidenceLevel);
 
   MechanismType getMechanismType();


### PR DESCRIPTION
- Add confidence interval functions to noise interface
- Add value-typed class for confidence Interval with double bounds
- Add confidence level check in DpPreconditions

Fixes:
- Add Infinite condition check for sensitivity parameters in DpPreconditions.Java