### PR TITLE
Windows support

### DIFF
--- a/cc/algorithms/BUILD
+++ b/cc/algorithms/BUILD
@@ -17,10 +17,19 @@ package(
     default_visibility = ["//visibility:public"],
 )
 
+config_setting(
+    name = "windows",
+    values = {"cpu": "x64_windows"},
+    visibility = ["//visibility:public"],
+)
+
 cc_library(
     name = "algorithm",
     hdrs = ["algorithm.h"],
-    copts = ["-Wno-sign-compare"],
+    copts = select({
+        ":windows": [],
+        "//conditions:default": ["-Wno-sign-compare"],
+    }),
     deps = [
         ":numerical-mechanisms",
         ":util",
@@ -38,7 +47,10 @@ cc_test(
     name = "algorithm_test",
     size = "small",
     srcs = ["algorithm_test.cc"],
-    copts = ["-Wno-sign-compare"],
+    copts = select({
+        ":windows": [],
+        "//conditions:default": ["-Wno-sign-compare"],
+    }),
     deps = [
         ":algorithm",
         "//base/testing:status_matchers",
@@ -50,7 +62,10 @@ cc_test(
     name = "algorithm-stochastic-dp_test",
     timeout = "eternal",
     srcs = ["algorithm-stochastic-dp_test.cc"],
-    copts = ["-Wno-sign-compare"],
+    copts = select({
+        ":windows": [],
+        "//conditions:default": ["-Wno-sign-compare"],
+    }),
     shard_count = 16,
     deps = [
         "@com_google_googletest//:gtest_main",
@@ -71,7 +86,10 @@ cc_test(
 cc_library(
     name = "binary-search",
     hdrs = ["binary-search.h"],
-    copts = ["-Wno-sign-compare"],
+    copts = select({
+        ":windows": [],
+        "//conditions:default": ["-Wno-sign-compare"],
+    }),
     deps = [
         ":algorithm",
         ":numerical-mechanisms",
@@ -86,7 +104,10 @@ cc_test(
     name = "binary-search_test",
     size = "small",
     srcs = ["binary-search_test.cc"],
-    copts = ["-Wno-sign-compare"],
+    copts = select({
+        ":windows": [],
+        "//conditions:default": ["-Wno-sign-compare"],
+    }),
     deps = [
         ":algorithm",
         ":binary-search",
@@ -102,7 +123,10 @@ cc_test(
 cc_library(
     name = "order-statistics",
     hdrs = ["order-statistics.h"],
-    copts = ["-Wno-sign-compare"],
+    copts = select({
+        ":windows": [],
+        "//conditions:default": ["-Wno-sign-compare"],
+    }),
     deps = [
         ":algorithm",
         ":binary-search",
@@ -117,7 +141,10 @@ cc_test(
     name = "order-statistics_test",
     size = "small",
     srcs = ["order-statistics_test.cc"],
-    copts = ["-Wno-sign-compare"],
+    copts = select({
+        ":windows": [],
+        "//conditions:default": ["-Wno-sign-compare"],
+    }),
     deps = [
         ":numerical-mechanisms-testing",
         ":order-statistics",
@@ -130,7 +157,10 @@ cc_test(
 cc_library(
     name = "bounded-sum",
     hdrs = ["bounded-sum.h"],
-    copts = ["-Wno-sign-compare"],
+    copts = select({
+        ":windows": [],
+        "//conditions:default": ["-Wno-sign-compare"],
+    }),
     deps = [
         ":algorithm",
         ":approx-bounds",
@@ -148,7 +178,10 @@ cc_test(
     name = "bounded-sum_test",
     size = "small",
     srcs = ["bounded-sum_test.cc"],
-    copts = ["-Wno-sign-compare"],
+    copts = select({
+        ":windows": [],
+        "//conditions:default": ["-Wno-sign-compare"],
+    }),
     deps = [
         ":algorithm",
         ":approx-bounds",
@@ -166,7 +199,10 @@ cc_test(
 cc_library(
     name = "bounded-mean",
     hdrs = ["bounded-mean.h"],
-    copts = ["-Wno-sign-compare"],
+    copts = select({
+        ":windows": [],
+        "//conditions:default": ["-Wno-sign-compare"],
+    }),
     deps = [
         ":algorithm",
         ":approx-bounds",
@@ -184,7 +220,10 @@ cc_test(
     name = "bounded-mean_test",
     size = "small",
     srcs = ["bounded-mean_test.cc"],
-    copts = ["-Wno-sign-compare"],
+    copts = select({
+        ":windows": [],
+        "//conditions:default": ["-Wno-sign-compare"],
+    }),
     deps = [
         ":approx-bounds",
         ":bounded-mean",
@@ -198,7 +237,10 @@ cc_test(
 cc_library(
     name = "bounded-variance",
     hdrs = ["bounded-variance.h"],
-    copts = ["-Wno-sign-compare"],
+    copts = select({
+        ":windows": [],
+        "//conditions:default": ["-Wno-sign-compare"],
+    }),
     deps = [
         ":algorithm",
         ":approx-bounds",
@@ -216,7 +258,10 @@ cc_test(
     name = "bounded-variance_test",
     size = "small",
     srcs = ["bounded-variance_test.cc"],
-    copts = ["-Wno-sign-compare"],
+    copts = select({
+        ":windows": [],
+        "//conditions:default": ["-Wno-sign-compare"],
+    }),
     deps = [
         ":approx-bounds",
         ":bounded-variance",
@@ -231,7 +276,10 @@ cc_test(
 cc_library(
     name = "bounded-standard-deviation",
     hdrs = ["bounded-standard-deviation.h"],
-    copts = ["-Wno-sign-compare"],
+    copts = select({
+        ":windows": [],
+        "//conditions:default": ["-Wno-sign-compare"],
+    }),
     deps = [
         ":algorithm",
         ":bounded-algorithm",
@@ -246,7 +294,10 @@ cc_test(
     name = "bounded-standard-deviation_test",
     size = "small",
     srcs = ["bounded-standard-deviation_test.cc"],
-    copts = ["-Wno-sign-compare"],
+    copts = select({
+        ":windows": [],
+        "//conditions:default": ["-Wno-sign-compare"],
+    }),
     deps = [
         ":approx-bounds",
         ":bounded-standard-deviation",
@@ -263,7 +314,10 @@ cc_test(
 cc_library(
     name = "count",
     hdrs = ["count.h"],
-    copts = ["-Wno-sign-compare"],
+    copts = select({
+        ":windows": [],
+        "//conditions:default": ["-Wno-sign-compare"],
+    }),
     deps = [
         ":algorithm",
         ":numerical-mechanisms",
@@ -277,7 +331,10 @@ cc_test(
     name = "count_test",
     size = "small",
     srcs = ["count_test.cc"],
-    copts = ["-Wno-sign-compare"],
+    copts = select({
+        ":windows": [],
+        "//conditions:default": ["-Wno-sign-compare"],
+    }),
     deps = [
         ":count",
         ":numerical-mechanisms-testing",
@@ -294,7 +351,10 @@ cc_library(
     name = "util",
     srcs = ["util.cc"],
     hdrs = ["util.h"],
-    copts = ["-Wno-sign-compare"],
+    copts = select({
+        ":windows": [],
+        "//conditions:default": ["-Wno-sign-compare"],
+    }),
     deps = [
         "//base:logging",
         "//base:status",
@@ -307,7 +367,10 @@ cc_test(
     name = "util_test",
     size = "small",
     srcs = ["util_test.cc"],
-    copts = ["-Wno-sign-compare"],
+    copts = select({
+        ":windows": [],
+        "//conditions:default": ["-Wno-sign-compare"],
+    }),
     deps = [
         ":distributions",
         ":numerical-mechanisms-testing",
@@ -321,7 +384,10 @@ cc_library(
     name = "distributions",
     srcs = ["distributions.cc"],
     hdrs = ["distributions.h"],
-    copts = ["-Wno-sign-compare"],
+    copts = select({
+        ":windows": [],
+        "//conditions:default": ["-Wno-sign-compare"],
+    }),
     visibility = ["//visibility:private"],
     deps = [
         ":rand",
@@ -338,7 +404,10 @@ cc_test(
     name = "distributions_test",
     size = "medium",
     srcs = ["distributions_test.cc"],
-    copts = ["-Wno-sign-compare"],
+    copts = select({
+        ":windows": [],
+        "//conditions:default": ["-Wno-sign-compare"],
+    }),
     shard_count = 4,
     deps = [
         ":distributions",
@@ -354,7 +423,10 @@ cc_test(
 cc_library(
     name = "numerical-mechanisms",
     hdrs = ["numerical-mechanisms.h"],
-    copts = ["-Wno-sign-compare"],
+    copts = select({
+        ":windows": [],
+        "//conditions:default": ["-Wno-sign-compare"],
+    }),
     deps = [
         ":distributions",
         ":util",
@@ -367,7 +439,10 @@ cc_test(
     name = "numerical-mechanisms_test",
     size = "small",
     srcs = ["numerical-mechanisms_test.cc"],
-    copts = ["-Wno-sign-compare"],
+    copts = select({
+        ":windows": [],
+        "//conditions:default": ["-Wno-sign-compare"],
+    }),
     deps = [
         ":distributions",
         ":numerical-mechanisms",
@@ -379,7 +454,10 @@ cc_library(
     name = "numerical-mechanisms-testing",
     testonly = 1,
     hdrs = ["numerical-mechanisms-testing.h"],
-    copts = ["-Wno-sign-compare"],
+    copts = select({
+        ":windows": [],
+        "//conditions:default": ["-Wno-sign-compare"],
+    }),
     deps = [
         ":distributions",
         ":numerical-mechanisms",
@@ -394,7 +472,10 @@ cc_test(
     name = "numerical-mechanisms-testing_test",
     size = "small",
     srcs = ["numerical-mechanisms-testing_test.cc"],
-    copts = ["-Wno-sign-compare"],
+    copts = select({
+        ":windows": [],
+        "//conditions:default": ["-Wno-sign-compare"],
+    }),
     deps = [
         ":numerical-mechanisms-testing",
         "@com_google_googletest//:gtest_main",
@@ -404,7 +485,10 @@ cc_test(
 cc_library(
     name = "approx-bounds",
     hdrs = ["approx-bounds.h"],
-    copts = ["-Wno-sign-compare"],
+    copts = select({
+        ":windows": [],
+        "//conditions:default": ["-Wno-sign-compare"],
+    }),
     deps = [
         ":algorithm",
         ":numerical-mechanisms",
@@ -418,7 +502,10 @@ cc_test(
     name = "approx-bounds_test",
     size = "small",
     srcs = ["approx-bounds_test.cc"],
-    copts = ["-Wno-sign-compare"],
+    copts = select({
+        ":windows": [],
+        "//conditions:default": ["-Wno-sign-compare"],
+    }),
     deps = [
         ":approx-bounds",
         ":numerical-mechanisms-testing",
@@ -432,7 +519,10 @@ cc_test(
 cc_library(
     name = "bounded-algorithm",
     hdrs = ["bounded-algorithm.h"],
-    copts = ["-Wno-sign-compare"],
+    copts = select({
+        ":windows": [],
+        "//conditions:default": ["-Wno-sign-compare"],
+    }),
     deps = [
         ":algorithm",
         ":approx-bounds",
@@ -444,7 +534,10 @@ cc_test(
     name = "bounded-algorithm_test",
     size = "small",
     srcs = ["bounded-algorithm_test.cc"],
-    copts = ["-Wno-sign-compare"],
+    copts = select({
+        ":windows": [],
+        "//conditions:default": ["-Wno-sign-compare"],
+    }),
     deps = [
         ":algorithm",
         ":approx-bounds",
@@ -458,7 +551,10 @@ cc_library(
     name = "rand",
     srcs = ["rand.cc"],
     hdrs = ["rand.h"],
-    copts = ["-Wno-sign-compare"],
+    copts = select({
+        ":windows": [],
+        "//conditions:default": ["-Wno-sign-compare"],
+    }),
     deps = [
         "//base:logging",
         "@boringssl//:crypto",
@@ -470,7 +566,10 @@ cc_test(
     name = "rand_test",
     size = "small",
     srcs = ["rand_test.cc"],
-    copts = ["-Wno-sign-compare"],
+    copts = select({
+        ":windows": [],
+        "//conditions:default": ["-Wno-sign-compare"],
+    }),
     deps = [
         ":rand",
         "@com_google_googletest//:gtest_main",
@@ -481,7 +580,10 @@ cc_test(
     name = "distributions_benchmark_test",
     timeout = "long",
     srcs = ["distributions_benchmark_test.cc"],
-    copts = ["-Wno-sign-compare"],
+    copts = select({
+        ":windows": [],
+        "//conditions:default": ["-Wno-sign-compare"],
+    }),
     deps = [
         ":distributions",
         "@com_google_benchmark//:benchmark_main",

--- a/cc/algorithms/approx-bounds.h
+++ b/cc/algorithms/approx-bounds.h
@@ -186,7 +186,7 @@ class ApproxBounds : public Algorithm<T> {
   };
 
   void AddEntry(const T& input) override {
-    if (std::isnan(input)) {
+    if (std::isnan(static_cast<double>(input))) { // REF: https://stackoverflow.com/questions/61646166/how-to-resolve-fpclassify-ambiguous-call-to-overloaded-function
       return;
     }
 

--- a/cc/algorithms/binary-search.h
+++ b/cc/algorithms/binary-search.h
@@ -81,7 +81,7 @@ template <typename T>
 class BinarySearch : public Algorithm<T> {
  public:
   void AddEntry(const T& t) override {
-    if (!std::isnan(t)) {
+    if (!std::isnan(static_cast<double>(t))) {
       quantiles_->Add(t);
     }
   }

--- a/cc/algorithms/bounded-mean.h
+++ b/cc/algorithms/bounded-mean.h
@@ -119,7 +119,7 @@ class BoundedMean : public Algorithm<T> {
   };
 
   void AddEntry(const T& t) override {
-    if (std::isnan(t)) {
+    if (std::isnan(static_cast<double>(t))) {
       return;
     }
     ++raw_count_;

--- a/cc/algorithms/bounded-sum.h
+++ b/cc/algorithms/bounded-sum.h
@@ -91,7 +91,7 @@ class BoundedSum : public Algorithm<T> {
   };
 
   void AddEntry(const T& t) override {
-    if (std::isnan(t)) {
+    if (std::isnan(static_cast<double>(t))) {
       return;
     }
 

--- a/cc/algorithms/bounded-variance.h
+++ b/cc/algorithms/bounded-variance.h
@@ -150,7 +150,7 @@ class BoundedVariance : public Algorithm<T> {
 
   void AddEntry(const T& t) override {
     // Drop value if it is NaN.
-    if (std::isnan(t)) {
+    if (std::isnan(static_cast<double>(t))) {
       return;
     }
 

--- a/cc/algorithms/numerical-mechanisms_test.cc
+++ b/cc/algorithms/numerical-mechanisms_test.cc
@@ -219,29 +219,29 @@ struct conf_int_params {
 
 // True bounds calculated using standard deviations of
 // 3.4855, 3.60742, 0.367936, respectively.
-struct conf_int_params gauss_params1 = {.epsilon = 1.2,
-                                        .delta = 0.3,
-                                        .sensitivity = 1.0,
-                                        .level = .9,
-                                        .budget = .5,
-                                        .result = 0,
-                                        .true_bound = -1.9613};
+struct conf_int_params gauss_params1 = {1.2,
+                                         0.3,
+                                         1.0,
+                                         .9,
+                                         .5,
+                                         0,
+                                         -1.9613};
 
-struct conf_int_params gauss_params2 = {.epsilon = 1.0,
-                                        .delta = 0.5,
-                                        .sensitivity = 1.0,
-                                        .level = .95,
-                                        .budget = .5,
-                                        .result = 1.3,
-                                        .true_bound = -1.9054};
+struct conf_int_params gauss_params2 = { 1.0,
+                                         0.5,
+                                         1.0,
+                                         .95,
+                                         .5,
+                                         1.3,
+                                         -1.9054};
 
-struct conf_int_params gauss_params3 = {.epsilon = 10.0,
-                                        .delta = 0.5,
-                                        .sensitivity = 1.0,
-                                        .level = .95,
-                                        .budget = .75,
-                                        .result = 2.7,
-                                        .true_bound = -0.5154};
+struct conf_int_params gauss_params3 = { 10.0,
+                                         0.5,
+                                         1.0,
+                                         .95,
+                                         .75,
+                                         2.7,
+                                         -0.5154};
 
 INSTANTIATE_TEST_SUITE_P(TestSuite, NoiseIntervalMultipleParametersTests,
                          testing::Values(gauss_params1, gauss_params2,

--- a/cc/base/BUILD
+++ b/cc/base/BUILD
@@ -24,10 +24,19 @@ package(
     ],
 )
 
+config_setting(
+    name = "windows",
+    values = {"cpu": "x64_windows"},
+    visibility = ["//visibility:public"],
+)
+
 cc_library(
     name = "percentile",
     hdrs = ["percentile.h"],
-    copts = ["-Wno-sign-compare"],
+    copts = select({
+        ":windows": [],
+        "//conditions:default": ["-Wno-sign-compare"],
+    }),
     deps = [
         "//proto:util-lib",
         "@com_google_protobuf//:protobuf_lite",
@@ -38,7 +47,10 @@ cc_library(
     name = "logging",
     srcs = ["logging.cc"],
     hdrs = ["logging.h"],
-    copts = ["-Wno-sign-compare"],
+    copts = select({
+        ":windows": [],
+        "//conditions:default": ["-Wno-sign-compare"],
+    }),
     deps = [
         "@com_google_absl//absl/base",
         "@com_google_absl//absl/base:core_headers",
@@ -49,7 +61,10 @@ cc_library(
 cc_library(
     name = "statusor_internals",
     hdrs = ["statusor_internals.h"],
-    copts = ["-Wno-sign-compare"],
+    copts = select({
+        ":windows": [],
+        "//conditions:default": ["-Wno-sign-compare"],
+    }),
     deps = [
         ":status",
         "@com_google_absl//absl/base:core_headers",
@@ -64,7 +79,10 @@ cc_library(
         "status.h",
         "status_macros.h",
     ],
-    copts = ["-Wno-sign-compare"],
+    copts = select({
+        ":windows": [],
+        "//conditions:default": ["-Wno-sign-compare"],
+    }),
     deps = [
         "@com_google_absl//absl/base:core_headers",
         "@com_google_absl//absl/container:node_hash_map",
@@ -77,7 +95,10 @@ cc_library(
     name = "canonical_errors",
     srcs = ["canonical_errors.cc"],
     hdrs = ["canonical_errors.h"],
-    copts = ["-Wno-sign-compare"],
+    copts = select({
+        ":windows": [],
+        "//conditions:default": ["-Wno-sign-compare"],
+    }),
     deps = [
         ":status",
         "@com_google_absl//absl/base:core_headers",
@@ -89,7 +110,10 @@ cc_library(
     name = "statusor",
     srcs = ["statusor.cc"],
     hdrs = ["statusor.h"],
-    copts = ["-Wno-sign-compare"],
+    copts = select({
+        ":windows": [],
+        "//conditions:default": ["-Wno-sign-compare"],
+    }),
     deps = [
         ":canonical_errors",
         ":logging",
@@ -102,7 +126,10 @@ cc_library(
 cc_test(
     name = "percentile_test",
     srcs = ["percentile_test.cc"],
-    copts = ["-Wno-sign-compare"],
+    copts = select({
+        ":windows": [],
+        "//conditions:default": ["-Wno-sign-compare"],
+    }),
     deps = [
         ":percentile",
         "@com_google_googletest//:gtest_main",
@@ -113,7 +140,10 @@ cc_test(
 cc_test(
     name = "status_test",
     srcs = ["status_test.cc"],
-    copts = ["-Wno-sign-compare"],
+    copts = select({
+        ":windows": [],
+        "//conditions:default": ["-Wno-sign-compare"],
+    }),
     deps = [
         ":status",
         "@com_google_googletest//:gtest_main",
@@ -123,7 +153,10 @@ cc_test(
 cc_test(
     name = "statusor_test",
     srcs = ["statusor_test.cc"],
-    copts = ["-Wno-sign-compare"],
+    copts = select({
+        ":windows": [],
+        "//conditions:default": ["-Wno-sign-compare"],
+    }),
     deps = [
         ":canonical_errors",
         ":statusor",
@@ -138,7 +171,10 @@ cc_test(
 cc_test(
     name = "status_macros_test",
     srcs = ["status_macros_test.cc"],
-    copts = ["-Wno-sign-compare"],
+    copts = select({
+        ":windows": [],
+        "//conditions:default": ["-Wno-sign-compare"],
+    }),
     deps = [
         ":status",
         ":statusor",

--- a/cc/base/logging.cc
+++ b/cc/base/logging.cc
@@ -52,7 +52,7 @@ static int clock_gettime(int, struct timespec *spec)      //C-file part
     return 0;
 }
 // END PATCH
-#elif
+#else
 #include <unistd.h>
 #endif
 

--- a/cc/base/logging.cc
+++ b/cc/base/logging.cc
@@ -24,22 +24,22 @@
 #include <sys/types.h>
 #ifdef _WIN32
 // START PATCH
-// HACK: This is not a solution just an attempt at see what is going on and getting PyDP to build on windows.
+// This `if` code block conditionally defines and imports windows system specific code.
+// This block defines the windows alternatives to the functions defined in <unistd.h> 
+// which is included in the `else` section below.
 #include <Windows.h>
-#include <time.h>
+#include <time.h> // for: timespec
 #include <io.h> // for: access 
 #include <direct.h> // for: _mkdir
-
+// By design Windows does not have a `mode` parameter.
 # undef mkdir
-# define mkdir(path, mode) _mkdir(path) // Fix api. Not sure 
+# define mkdir(path, mode) _mkdir(path)  
 
 #ifndef S_ISDIR
 #define S_ISDIR(mode) (((mode) & S_IFMT) == S_IFDIR)
 #endif
 
-#define R_OK 4
 #define W_OK 2
-#define X_OK 0
 #define F_OK 0
 #define CLOCK_REALTIME 0
 
@@ -51,7 +51,6 @@ static int clock_gettime(int, struct timespec *spec)      //C-file part
     spec->tv_nsec = wintime % 10000000i64 * 100;      //nano-seconds
     return 0;
 }
-
 // END PATCH
 #elif
 #include <unistd.h>

--- a/cc/base/logging.cc
+++ b/cc/base/logging.cc
@@ -22,7 +22,40 @@
 #include <string.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#ifdef _WIN32
+// START PATCH
+// HACK: This is not a solution just an attempt at see what is going on and getting PyDP to build on windows.
+#include <Windows.h>
+#include <time.h>
+#include <io.h> // for: access 
+#include <direct.h> // for: _mkdir
+
+# undef mkdir
+# define mkdir(path, mode) _mkdir(path) // Fix api. Not sure 
+
+#ifndef S_ISDIR
+#define S_ISDIR(mode) (((mode) & S_IFMT) == S_IFDIR)
+#endif
+
+#define R_OK 4
+#define W_OK 2
+#define X_OK 0
+#define F_OK 0
+#define CLOCK_REALTIME 0
+
+static int clock_gettime(int, struct timespec *spec)      //C-file part
+{
+    __int64 wintime; GetSystemTimeAsFileTime((FILETIME*)&wintime);
+    wintime -= 116444736000000000i64;  //1jan1601 to 1jan1970
+    spec->tv_sec = wintime / 10000000i64;           //seconds
+    spec->tv_nsec = wintime % 10000000i64 * 100;      //nano-seconds
+    return 0;
+}
+
+// END PATCH
+#elif
 #include <unistd.h>
+#endif
 
 #include <cctype>
 #include <cstdio>

--- a/cc/base/percentile.h
+++ b/cc/base/percentile.h
@@ -52,7 +52,7 @@ class Percentile {
   Percentile() {}
 
   void Add(const T& t) {
-    if (!std::isnan(t)) {
+    if (!std::isnan(static_cast<double>(t))) {
       inputs_.push_back(t);
       sorted_ = false;
     }

--- a/cc/base/testing/BUILD
+++ b/cc/base/testing/BUILD
@@ -23,11 +23,20 @@ package(
     ],
 )
 
+config_setting(
+    name = "windows",
+    values = {"cpu": "x64_windows"},
+    visibility = ["//visibility:public"],
+)
+
 cc_library(
     name = "proto_matchers",
     testonly = 1,
     hdrs = ["proto_matchers.h"],
-    copts = ["-Wno-sign-compare"],
+    copts = select({
+        ":windows": [],
+        "//conditions:default": ["-Wno-sign-compare"],
+    }),
     deps = [
         "@com_google_googletest//:gtest_main",
         "@com_google_absl//absl/strings",
@@ -40,7 +49,10 @@ cc_library(
     testonly = 1,
     srcs = ["status_matchers.cc"],
     hdrs = ["status_matchers.h"],
-    copts = ["-Wno-sign-compare"],
+    copts = select({
+        ":windows": [],
+        "//conditions:default": ["-Wno-sign-compare"],
+    }),
     deps = [
         "@com_google_googletest//:gtest",
         "//base:status",
@@ -53,7 +65,10 @@ cc_test(
     name = "status_matchers_test",
     size = "small",
     srcs = ["status_matchers_test.cc"],
-    copts = ["-Wno-sign-compare"],
+    copts = select({
+        ":windows": [],
+        "//conditions:default": ["-Wno-sign-compare"],
+    }),
     deps = [
         ":status_matchers",
         "@com_google_googletest//:gtest_main",

--- a/cc/postgres/BUILD
+++ b/cc/postgres/BUILD
@@ -26,6 +26,10 @@ config_setting(
     name = "darwin_build",
     values = {"cpu": "darwin"},
 )
+config_setting(
+    name = "windows",
+    values = {"cpu": "x64_windows"},
+)
 
 cc_binary(
     name = "anon_func.so",
@@ -68,7 +72,10 @@ cc_library(
     name = "dp_func",
     srcs = ["dp_func.cc"],
     hdrs = ["dp_func.h"],
-    copts = ["-Wno-sign-compare"],
+    copts = select({
+        ":windows": [],
+        "//conditions:default": ["-Wno-sign-compare"],
+    }),
     deps = [
         "//algorithms:algorithm",
         "//algorithms:bounded-mean",
@@ -84,7 +91,10 @@ cc_library(
 cc_test(
     name = "dp_func_test",
     srcs = ["dp_func_test.cc"],
-    copts = ["-Wno-sign-compare"],
+    copts = select({
+        ":windows": [],
+        "//conditions:default": ["-Wno-sign-compare"],
+    }),
     deps = [
         ":dp_func",
         "@com_google_googletest//:gtest_main",

--- a/cc/proto/BUILD
+++ b/cc/proto/BUILD
@@ -17,18 +17,27 @@
 # Differential Privacy related proto utilities.
 
 package(default_visibility = ["//visibility:public"])
-
+config_setting(
+    name = "windows",
+    values = {"cpu": "x64_windows"},
+)
 cc_library(
     name = "util-lib",
     hdrs = ["util.h"],
-    copts = ["-Wno-sign-compare"],
+    copts = select({
+        ":windows": [],
+        "//conditions:default": ["-Wno-sign-compare"],
+    }),
     deps = ["@com_google_differential_privacy//proto:data_cc_proto"],
 )
 
 cc_test(
     name = "util_test",
     srcs = ["util_test.cc"],
-    copts = ["-Wno-sign-compare"],
+    copts = select({
+        ":windows": [],
+        "//conditions:default": ["-Wno-sign-compare"],
+    }),
     deps = [
         ":util-lib",
         "@com_google_googletest//:gtest_main",

--- a/cc/testing/BUILD
+++ b/cc/testing/BUILD
@@ -16,11 +16,18 @@
 package(
     default_visibility = ["//visibility:public"],
 )
+config_setting(
+    name = "windows",
+    values = {"cpu": "x64_windows"},
+)
 
 cc_library(
     name = "sequence",
     hdrs = ["sequence.h"],
-    copts = ["-Wno-sign-compare"],
+    copts = select({
+        ":windows": [],
+        "//conditions:default": ["-Wno-sign-compare"],
+    }),
     deps = [
         "//base:logging",
         "@com_google_absl//absl/memory",
@@ -32,7 +39,10 @@ cc_test(
     name = "sequence_test",
     size = "small",
     srcs = ["sequence_test.cc"],
-    copts = ["-Wno-sign-compare"],
+    copts = select({
+        ":windows": [],
+        "//conditions:default": ["-Wno-sign-compare"],
+    }),
     deps = [
         ":sequence",
         "@com_google_googletest//:gtest_main",
@@ -44,7 +54,10 @@ cc_test(
 cc_library(
     name = "stochastic_tester",
     hdrs = ["stochastic_tester.h"],
-    copts = ["-Wno-sign-compare"],
+    copts = select({
+        ":windows": [],
+        "//conditions:default": ["-Wno-sign-compare"],
+    }),
     deps = [
         ":density_estimation",
         ":sequence",
@@ -61,7 +74,10 @@ cc_library(
 cc_library(
     name = "density_estimation",
     hdrs = ["density_estimation.h"],
-    copts = ["-Wno-sign-compare"],
+    copts = select({
+        ":windows": [],
+        "//conditions:default": ["-Wno-sign-compare"],
+    }),
     deps = [
         "//base:status",
         "//base:statusor",
@@ -75,7 +91,10 @@ cc_test(
     size = "small",
     timeout = "long",
     srcs = ["stochastic_tester_test.cc"],
-    copts = ["-Wno-sign-compare"],
+    copts = select({
+        ":windows": [],
+        "//conditions:default": ["-Wno-sign-compare"],
+    }),
     shard_count = 10,
     deps = [
         ":sequence",
@@ -94,7 +113,10 @@ cc_test(
 cc_test(
     name = "density_estimation_test",
     srcs = ["density_estimation_test.cc"],
-    copts = ["-Wno-sign-compare"],
+    copts = select({
+        ":windows": [],
+        "//conditions:default": ["-Wno-sign-compare"],
+    }),
     deps = [
         ":density_estimation",
         "//base:status",


### PR DESCRIPTION
This PR addresses #18 (and OpenMined/PyDP#112 of the downstream OpenMined PyDP project)

There are 4 types of issues that blocked the windows build.
1. `std::isnan` on windows does not do an implicit cast to `double` and causes a compiler error: `C2668 'fpclassify': ambiguous call to overloaded function` [See](https://github.com/google/differential-privacy/commit/89dfc542fed2fa9be7d1ec05be56ff2e71789d16)
2. `copts= ["-Wno-sign-compare"]` are not supported on windows. I tried using bazel `features` to turn remove it but either it's not possible or I miss understood how. The solution I used is below. I note this as I'm sure bazel has standard ways of addressing these kinds of use cases but I'm very unfamiliar with bazel. [See](https://github.com/google/differential-privacy/commit/a3c56aaf6664262f17754fc00fc5d3c09bff65ea)
```
    copts = select({
        ":windows": [],
        "//conditions:default": ["-Wno-sign-compare"],
    }),
```
3. The build specifies `c++17` however cl.exe Version 19.26.28806 for x64 does not support designated initializes. A few structs that make use of designated initializes had to be reverted to the previous form. [See](https://github.com/google/differential-privacy/commit/bf24f044e015956540852f50d1b4512fa470da24)
4. The `base/logging.cc` file makes use of a unix only header `unistd.h`. A patch of the form of a `#ifdef` block is needed to conditionally include platform specific alternatives. [See](https://github.com/google/differential-privacy/commit/d998de818689b6b4466ab8c86075498cd948445e)

Aside from these 4 rather small issues (all if which have a proposed single commit fixing them) the code base is fully compatible with windows:grin:!     
