### PR TITLE
Golang: Confidence interval for Count aggregation

### DIFF
--- a/go/dpagg/count.go
+++ b/go/dpagg/count.go
@@ -186,6 +186,7 @@ func (c *Count) ThresholdedResult(thresholdDelta float64) *int64 {
 
 // ComputeConfidenceInterval computes a confidence interval with integer bounds that contains the true count
 // with a probability greater than or equal to 1 - alpha using the noised count computed by Result().
+// 
 // Note Result() needs to be called before ComputeConfidenceInterval, otherwise this will return an error.
 func (c *Count) ComputeConfidenceInterval(alpha float64) (noise.ConfidenceInterval, error) {
 	if !c.resultReturned {

--- a/go/dpagg/count.go
+++ b/go/dpagg/count.go
@@ -18,6 +18,7 @@ package dpagg
 
 import (
 	"fmt"
+	"math"
 
 	log "github.com/golang/glog"
 	"github.com/google/differential-privacy/go/noise"
@@ -53,6 +54,7 @@ type Count struct {
 	// State variables
 	count          int64
 	resultReturned bool // whether the result has already been returned
+	noisedCount    int64
 }
 
 func countEquallyInitialized(c1, c2 *Count) bool {
@@ -166,7 +168,8 @@ func (c *Count) Result() int64 {
 		log.Fatalf("The count has already been calculated and returned. It can only be returned once.")
 	}
 	c.resultReturned = true
-	return c.noise.AddNoiseInt64(c.count, c.l0Sensitivity, c.lInfSensitivity, c.epsilon, c.delta)
+	c.noisedCount = c.noise.AddNoiseInt64(c.count, c.l0Sensitivity, c.lInfSensitivity, c.epsilon, c.delta)
+	return c.noisedCount
 }
 
 // ThresholdedResult is similar to Result() but applies thresholding to the
@@ -179,6 +182,20 @@ func (c *Count) ThresholdedResult(thresholdDelta float64) *int64 {
 		return nil
 	}
 	return &result
+}
+
+// ComputeConfidenceInterval computes a confidence interval with integer bounds that contains the true count with
+// a probability greater or equal to 1 - alpha using the noised count computed by Result().
+func (c *Count) ComputeConfidenceInterval(alpha float64) (noise.ConfidenceInterval, error) {
+	if !c.resultReturned {
+		return noise.ConfidenceInterval{}, fmt.Errorf("Noised count has not been computed yet")
+	}
+	confInt, err := c.noise.ComputeConfidenceIntervalInt64(c.noisedCount, c.l0Sensitivity, c.lInfSensitivity, c.epsilon, c.delta, alpha)
+	if err != nil {
+		return noise.ConfidenceInterval{}, err
+	}
+	confInt.LowerBound, confInt.UpperBound = math.Max(0, confInt.LowerBound), math.Max(0, confInt.UpperBound)
+	return confInt, nil
 }
 
 // encodableCount can be encoded by the gob package.

--- a/go/dpagg/count.go
+++ b/go/dpagg/count.go
@@ -184,16 +184,18 @@ func (c *Count) ThresholdedResult(thresholdDelta float64) *int64 {
 	return &result
 }
 
-// ComputeConfidenceInterval computes a confidence interval with integer bounds that contains the true count with
-// a probability greater or equal to 1 - alpha using the noised count computed by Result().
+// ComputeConfidenceInterval computes a confidence interval with integer bounds that contains the true count
+// with a probability greater than or equal to 1 - alpha using the noised count computed by Result().
+// Note Result() needs to be called before ComputeConfidenceInterval, otherwise this will return an error.
 func (c *Count) ComputeConfidenceInterval(alpha float64) (noise.ConfidenceInterval, error) {
 	if !c.resultReturned {
-		return noise.ConfidenceInterval{}, fmt.Errorf("Noised count has not been computed yet")
+		return noise.ConfidenceInterval{}, fmt.Errorf("You need to call Result() before calling ComputeConfidenceInterval()")
 	}
 	confInt, err := c.noise.ComputeConfidenceIntervalInt64(c.noisedCount, c.l0Sensitivity, c.lInfSensitivity, c.epsilon, c.delta, alpha)
 	if err != nil {
 		return noise.ConfidenceInterval{}, err
 	}
+	// True count cannot be negative.
 	confInt.LowerBound, confInt.UpperBound = math.Max(0, confInt.LowerBound), math.Max(0, confInt.UpperBound)
 	return confInt, nil
 }

--- a/go/dpagg/count_test.go
+++ b/go/dpagg/count_test.go
@@ -345,6 +345,93 @@ func TestCountThresholdedResult(t *testing.T) {
 	}
 }
 
+func TestCountComputeConfidenceIntervalPostProcessing(t *testing.T) {
+	// Confidence interval bounds for count should be non-negative.
+	for _, tc := range []struct {
+		confInt noise.ConfidenceInterval // Pre-processing.
+		want    noise.ConfidenceInterval // Post-processing.
+	}{
+		{
+			confInt: noise.ConfidenceInterval{LowerBound: 5, UpperBound: 10},
+			want:    noise.ConfidenceInterval{LowerBound: 5, UpperBound: 10},
+		},
+		{
+			confInt: noise.ConfidenceInterval{LowerBound: -5, UpperBound: 5},
+			want:    noise.ConfidenceInterval{LowerBound: 0, UpperBound: 5},
+		},
+		{
+			confInt: noise.ConfidenceInterval{LowerBound: -5, UpperBound: -5},
+			want:    noise.ConfidenceInterval{LowerBound: 0, UpperBound: 0},
+		},
+		// Infinite bounds happens for extremely small alpha for Gaussian.
+		{
+			confInt: noise.ConfidenceInterval{LowerBound: math.Inf(-1), UpperBound: math.Inf(1)},
+			want:    noise.ConfidenceInterval{LowerBound: 0, UpperBound: math.Inf(1)},
+		},
+	} {
+		c := getNoiselessCount()
+		// This makes Noise interface return the pre-processing confidence interval when ComputeConfidenceIntervalInt64 is called.
+		c.noise = getMockConfInt(tc.confInt)
+
+		c.Result()
+		got, _ := c.ComputeConfidenceInterval(0.1) // alpha is ignored in mockConfInt.
+
+		if got.LowerBound != tc.want.LowerBound {
+			t.Errorf("TestCountComputeConfidenceIntervalPostProcessing(ConfidenceInterval{%f, %f})=%0.10f, want %0.10f, LowerBounds are not equal",
+				tc.confInt.LowerBound, tc.confInt.UpperBound, got.LowerBound, tc.want.LowerBound)
+		}
+		if got.UpperBound != tc.want.UpperBound {
+			t.Errorf("TestCountComputeConfidenceIntervalPostProcessing(ConfidenceInterval{%f, %f})=%0.10f, want %0.10f, UpperBounds are not equal",
+				tc.confInt.LowerBound, tc.confInt.UpperBound, got.UpperBound, tc.want.UpperBound)
+		}
+	}
+}
+
+func TestCountComputeConfidenceIntervalComputation(t *testing.T) {
+	// Tests returned confidence intervals using Laplace or Gaussian for a given count.
+	for _, tc := range []struct {
+		desc string
+		opt  *CountOptions
+		want noise.ConfidenceInterval
+	}{
+		{
+			desc: "Gaussian",
+			opt:  &CountOptions{Epsilon: 0.1, Delta: 0.1, Noise: getNoiselessConfInt(noise.Gaussian())},
+			want: noise.ConfidenceInterval{LowerBound: 8, UpperBound: 12},
+		},
+		{
+			desc: "Laplace",
+			opt:  &CountOptions{Epsilon: 0.1, Noise: getNoiselessConfInt(noise.Laplace())},
+			want: noise.ConfidenceInterval{LowerBound: 3, UpperBound: 17},
+		},
+	} {
+		c := NewCount(tc.opt)
+		for i := 0; i < 10; i++ {
+			c.Increment()
+		}
+		c.Result()
+		got, _ := c.ComputeConfidenceInterval(0.5)
+
+		if got.LowerBound != tc.want.LowerBound {
+			t.Errorf("TestCountComputeConfidenceIntervalComputation(Noise: %s)=%0.10f, want %0.10f, LowerBounds are not equal",
+				tc.desc, got.LowerBound, tc.want.LowerBound)
+		}
+		if got.UpperBound != tc.want.UpperBound {
+			t.Errorf("TestCountComputeConfidenceIntervalComputation(Noise: %s)=%0.10f, want %0.10f, UpperBounds are not equal",
+				tc.desc, got.UpperBound, tc.want.UpperBound)
+		}
+	}
+}
+
+func TestCountComputeConfIntCannotBeCalledBeforeResult(t *testing.T) {
+	c := getNoiselessCount()
+	// Calling ComputeConfidenceInterval without calling Result() first will produce an error.
+	_, err := c.ComputeConfidenceInterval(0.1)
+	if err == nil {
+		t.Errorf("TestCountComputeConfIntCannotBeCalledBeforeResult: No error was returned")
+	}
+}
+
 type mockNoiseCount struct {
 	t *testing.T
 	noise.Noise
@@ -390,6 +477,29 @@ func (mn mockNoiseCount) Threshold(l0 int64, lInf, eps, del, thresholdDelta floa
 	return 0 // ignored
 }
 
+// ComputeConfidenceIntervalInt64 checks that the parameters passed are the ones we expect.
+func (mn mockNoiseCount) ComputeConfidenceIntervalInt64(noisedX, l0, lInf int64, eps, del, alpha float64) (noise.ConfidenceInterval, error) {
+	if noisedX != 0 { // AddNoiseInt64 returns a noised value of zero in mockNoiseCount.
+		mn.t.Errorf("ComputeConfidenceIntervalInt64: for parameter x got %d, want %d", noisedX, 0)
+	}
+	if l0 != 3 {
+		mn.t.Errorf("ComputeConfidenceIntervalInt64: for parameter l0Sensitivity got %d, want %d", l0, 3)
+	}
+	if lInf != 2 {
+		mn.t.Errorf("ComputeConfidenceIntervalInt64: for parameter lInfSensitivity got %d, want %d", lInf, 2)
+	}
+	if !ApproxEqual(eps, ln3) {
+		mn.t.Errorf("ComputeConfidenceIntervalInt64: for parameter epsilon got %f, want %f", eps, ln3)
+	}
+	if !ApproxEqual(del, tenten) {
+		mn.t.Errorf("ComputeConfidenceIntervalInt64: for parameter delta got %f, want %f", del, tenten)
+	}
+	if !ApproxEqual(alpha, alphaLevel) {
+		mn.t.Errorf("ComputeConfidenceIntervalInt64: for parameter alpha got %f, want %f", alpha, alphaLevel)
+	}
+	return noise.ConfidenceInterval{}, nil
+}
+
 func getMockCount(t *testing.T) *Count {
 	return NewCount(&CountOptions{
 		Epsilon:                      ln3,
@@ -414,6 +524,12 @@ func TestThresholdIsCorrectlyCalledForCount(t *testing.T) {
 		count.Increment()
 	}
 	count.ThresholdedResult(20) // will fail if parameters are wrong
+}
+
+func TestComputeConfidenceIntervalInt64IsCorrectlyCalledForCount(t *testing.T) {
+	count := getMockCount(t)
+	count.Result()
+	count.ComputeConfidenceInterval(alphaLevel) // will fail if parameters are wrong
 }
 
 func TestCountEquallyInitialized(t *testing.T) {

--- a/go/dpagg/count_test.go
+++ b/go/dpagg/count_test.go
@@ -345,11 +345,11 @@ func TestCountThresholdedResult(t *testing.T) {
 	}
 }
 
+// Tests that confidence interval bounds for count are non-negative.
 func TestCountComputeConfidenceIntervalPostProcessing(t *testing.T) {
-	// Confidence interval bounds for count should be non-negative.
 	for _, tc := range []struct {
-		confInt noise.ConfidenceInterval // Pre-processing.
-		want    noise.ConfidenceInterval // Post-processing.
+		confInt noise.ConfidenceInterval // Raw confidence interval.
+		want    noise.ConfidenceInterval // Confidence interval after post-processing.
 	}{
 		{
 			confInt: noise.ConfidenceInterval{LowerBound: 5, UpperBound: 10},
@@ -370,7 +370,7 @@ func TestCountComputeConfidenceIntervalPostProcessing(t *testing.T) {
 		},
 	} {
 		c := getNoiselessCount()
-		// This makes Noise interface return the pre-processing confidence interval when ComputeConfidenceIntervalInt64 is called.
+		// This makes Noise interface return the raw confidence interval when ComputeConfidenceIntervalInt64 is called.
 		c.noise = getMockConfInt(tc.confInt)
 
 		c.Result()
@@ -387,8 +387,8 @@ func TestCountComputeConfidenceIntervalPostProcessing(t *testing.T) {
 	}
 }
 
+// Tests that ComputeConfidenceInterval returns a correct interval for a given count.
 func TestCountComputeConfidenceIntervalComputation(t *testing.T) {
-	// Tests returned confidence intervals using Laplace or Gaussian for a given count.
 	for _, tc := range []struct {
 		desc string
 		opt  *CountOptions
@@ -423,12 +423,12 @@ func TestCountComputeConfidenceIntervalComputation(t *testing.T) {
 	}
 }
 
-func TestCountComputeConfIntCannotBeCalledBeforeResult(t *testing.T) {
+// Tests that calling ComputeConfidenceInterval without calling Result() produces an error.
+func TestCountComputeConfindenceIntervalCannotBeCalledBeforeResult(t *testing.T) {
 	c := getNoiselessCount()
-	// Calling ComputeConfidenceInterval without calling Result() first will produce an error.
 	_, err := c.ComputeConfidenceInterval(0.1)
 	if err == nil {
-		t.Errorf("TestCountComputeConfIntCannotBeCalledBeforeResult: No error was returned")
+		t.Errorf("TestCountComputeConfindenceIntervalCannotBeCalledBeforeResult: No error was returned, expected error")
 	}
 }
 

--- a/go/dpagg/dpagg_test.go
+++ b/go/dpagg/dpagg_test.go
@@ -69,8 +69,8 @@ func getNoiselessConfInt(noise noise.Noise) noise.Noise {
 	return noNoise{noise}
 }
 
-// mockConfInt is a Noise instance that returns an already set confidence interval.
-// Useful in testing post-processing in confidence intervals.
+// mockConfInt is a Noise instance that returns a pre-set confidence interval.
+// Useful for testing post-processing in confidence intervals.
 type mockConfInt struct {
 	noNoise
 	confInt noise.ConfidenceInterval


### PR DESCRIPTION
- Add confidence interval to count aggregation with tests.
- Add mock noise structs for testing with Confidence intervals.