### PR TITLE
Golang: Confidence interval for BoundedSum aggregation

### DIFF
--- a/go/dpagg/dpagg_test.go
+++ b/go/dpagg/dpagg_test.go
@@ -69,8 +69,13 @@ func getNoiselessConfInt(noise noise.Noise) noise.Noise {
 	return noNoise{noise}
 }
 
+<<<<<<< HEAD
 // mockConfInt is a Noise instance that returns a pre-set confidence interval.
 // Useful for testing post-processing in confidence intervals.
+=======
+// mockConfInt is a Noise instance that returns an already set confidence interval.
+// Useful in testing post-processing in confidence intervals.
+>>>>>>> Go: Add Confidence Intervals for BoundedSum aggregation.
 type mockConfInt struct {
 	noNoise
 	confInt noise.ConfidenceInterval

--- a/go/dpagg/dpagg_test.go
+++ b/go/dpagg/dpagg_test.go
@@ -69,13 +69,8 @@ func getNoiselessConfInt(noise noise.Noise) noise.Noise {
 	return noNoise{noise}
 }
 
-<<<<<<< HEAD
 // mockConfInt is a Noise instance that returns a pre-set confidence interval.
 // Useful for testing post-processing in confidence intervals.
-=======
-// mockConfInt is a Noise instance that returns an already set confidence interval.
-// Useful in testing post-processing in confidence intervals.
->>>>>>> Go: Add Confidence Intervals for BoundedSum aggregation.
 type mockConfInt struct {
 	noNoise
 	confInt noise.ConfidenceInterval

--- a/go/dpagg/sum.go
+++ b/go/dpagg/sum.go
@@ -252,10 +252,11 @@ func (bs *BoundedSumInt64) ThresholdedResult(thresholdDelta float64) *int64 {
 }
 
 // ComputeConfidenceInterval computes a confidence interval with integer bounds that contains the true sum with
-// a probability greater or equal to 1 - alpha using the noised sum computed by Result().
+// a probability greater than or equal to 1 - alpha using the noised sum computed by Result(). Note Result()
+// needs to be called before ComputeConfidenceInterval, otherwise this will return an error.
 func (bs *BoundedSumInt64) ComputeConfidenceInterval(alpha float64) (noise.ConfidenceInterval, error) {
 	if !bs.resultReturned {
-		return noise.ConfidenceInterval{}, fmt.Errorf("Noised sum has not been computed yet")
+		return noise.ConfidenceInterval{}, fmt.Errorf("You need to call Result() before calling ComputeConfidenceInterval()")
 	}
 	confInt, err := bs.noise.ComputeConfidenceIntervalInt64(bs.noisedSum, bs.l0Sensitivity, bs.lInfSensitivity, bs.epsilon, bs.delta, alpha)
 	if err != nil {
@@ -543,10 +544,11 @@ func (bs *BoundedSumFloat64) ThresholdedResult(thresholdDela float64) *float64 {
 }
 
 // ComputeConfidenceInterval computes a confidence interval that contains the true sum with
-// a probability equal to 1 - alpha using the noised sum computed by Result().
+// a probability equal to 1 - alpha using the noised sum computed by Result(). Note Result()
+// needs to be called before ComputeConfidenceInterval, otherwise this will return an error.
 func (bs *BoundedSumFloat64) ComputeConfidenceInterval(alpha float64) (noise.ConfidenceInterval, error) {
 	if !bs.resultReturned {
-		return noise.ConfidenceInterval{}, fmt.Errorf("Noised sum has not been computed yet")
+		return noise.ConfidenceInterval{}, fmt.Errorf("You need to call Result() before calling ComputeConfidenceInterval()")
 	}
 	confInt, err := bs.noise.ComputeConfidenceIntervalFloat64(bs.noisedSum, bs.l0Sensitivity, bs.lInfSensitivity, bs.epsilon, bs.delta, alpha)
 	if err != nil {

--- a/go/dpagg/sum.go
+++ b/go/dpagg/sum.go
@@ -252,8 +252,9 @@ func (bs *BoundedSumInt64) ThresholdedResult(thresholdDelta float64) *int64 {
 }
 
 // ComputeConfidenceInterval computes a confidence interval with integer bounds that contains the true sum with
-// a probability greater than or equal to 1 - alpha using the noised sum computed by Result(). Note Result()
-// needs to be called before ComputeConfidenceInterval, otherwise this will return an error.
+// a probability greater than or equal to 1 - alpha using the noised sum computed by Result(). 
+//
+// Note Result() needs to be called before ComputeConfidenceInterval, otherwise this will return an error.
 func (bs *BoundedSumInt64) ComputeConfidenceInterval(alpha float64) (noise.ConfidenceInterval, error) {
 	if !bs.resultReturned {
 		return noise.ConfidenceInterval{}, fmt.Errorf("You need to call Result() before calling ComputeConfidenceInterval()")
@@ -262,11 +263,11 @@ func (bs *BoundedSumInt64) ComputeConfidenceInterval(alpha float64) (noise.Confi
 	if err != nil {
 		return noise.ConfidenceInterval{}, err
 	}
-	// If lower and upper bounds are non-negative, trim any negative interval.
+	// If lower and upper bounds are non-negative, trim the negative part of the interval.
 	if bs.lower >= 0 && bs.upper >= 0 {
 		confInt.LowerBound, confInt.UpperBound = math.Max(0, confInt.LowerBound), math.Max(0, confInt.UpperBound)
 	}
-	// Similarly, if lower and upper bounds are non-positive, trim any positive interval.
+	// Similarly, if lower and upper bounds are non-positive, trim the positive part of the interval.
 	if bs.lower <= 0 && bs.upper <= 0 {
 		confInt.LowerBound, confInt.UpperBound = math.Min(0, confInt.LowerBound), math.Min(0, confInt.UpperBound)
 	}
@@ -544,8 +545,9 @@ func (bs *BoundedSumFloat64) ThresholdedResult(thresholdDela float64) *float64 {
 }
 
 // ComputeConfidenceInterval computes a confidence interval that contains the true sum with
-// a probability equal to 1 - alpha using the noised sum computed by Result(). Note Result()
-// needs to be called before ComputeConfidenceInterval, otherwise this will return an error.
+// a probability equal to 1 - alpha using the noised sum computed by Result().
+//
+//  Note Result() needs to be called before ComputeConfidenceInterval, otherwise this will return an error.
 func (bs *BoundedSumFloat64) ComputeConfidenceInterval(alpha float64) (noise.ConfidenceInterval, error) {
 	if !bs.resultReturned {
 		return noise.ConfidenceInterval{}, fmt.Errorf("You need to call Result() before calling ComputeConfidenceInterval()")
@@ -554,11 +556,11 @@ func (bs *BoundedSumFloat64) ComputeConfidenceInterval(alpha float64) (noise.Con
 	if err != nil {
 		return noise.ConfidenceInterval{}, err
 	}
-	// If lower and upper bounds are non-negative, trim any negative interval.
+	// If lower and upper bounds are non-negative, trim the negative part of the interval.
 	if bs.lower >= 0 && bs.upper >= 0 {
 		confInt.LowerBound, confInt.UpperBound = math.Max(0, confInt.LowerBound), math.Max(0, confInt.UpperBound)
 	}
-	// Similarly if lower and upper bounds are non-positive, trim any positive interval.
+	// Similarly if lower and upper bounds are non-positive, trim the positive part of the interval.
 	if bs.lower <= 0 && bs.upper <= 0 {
 		confInt.LowerBound, confInt.UpperBound = math.Min(0, confInt.LowerBound), math.Min(0, confInt.UpperBound)
 	}

--- a/go/dpagg/sum_test.go
+++ b/go/dpagg/sum_test.go
@@ -903,15 +903,14 @@ func TestThresholdedResultFloat64(t *testing.T) {
 	}
 }
 
-// Tests ComputeConfidenceInterval that If both bounds are non-negative, then trim any negative interval. Similarly, if both
-// bounds are non-positive then trim any positive interval from the confidence interval.
+// Tests that ComputeConfidenceInterval for int64 trims negative intervals if both bounds are non-negative;
+// and trims positive intervals if both bounds are non-positive.
 func TestSumComputeConfidenceIntervalForInt64PostProcessing(t *testing.T) {
-	// noNoise is set to skip initial argument checking.
-	noNoise := noNoise{}
+	noNoise := noNoise{} // To skip initial argument checking.
 	for _, tc := range []struct {
 		opt     *BoundedSumInt64Options
 		confInt noise.ConfidenceInterval // Raw confidence interval.
-		want    noise.ConfidenceInterval // Post-processing.
+		want    noise.ConfidenceInterval // Confidence Interval after Post-processing.
 	}{
 		{
 			opt:     &BoundedSumInt64Options{Lower: 2, Upper: 3, Noise: noNoise},
@@ -958,15 +957,14 @@ func TestSumComputeConfidenceIntervalForInt64PostProcessing(t *testing.T) {
 	}
 }
 
-// Tests ComputeConfidenceInterval that If both bounds are non-negative, then trim any negative interval. Similarly, if both
-// bounds are non-positive then trim any positive interval from the confidence interval.
+// Tests that ComputeConfidenceInterval for float64 trims negative intervals if both bounds are non-negative;
+// and trims positive intervals if both bounds are non-positive.
 func TestSumComputeConfidenceIntervalForFloat64PostProcessing(t *testing.T) {
-	// noNoise is set to skip initial argument checking.
-	noNoise := noNoise{}
+	noNoise := noNoise{} // To skip initial argument checking.
 	for _, tc := range []struct {
 		opt     *BoundedSumFloat64Options
 		confInt noise.ConfidenceInterval // Raw confidence interval.
-		want    noise.ConfidenceInterval // Post-processing.
+		want    noise.ConfidenceInterval // Confidence Interval after Post-processing.
 	}{
 		{
 			opt:     &BoundedSumFloat64Options{Lower: 2, Upper: 3, Noise: noNoise},
@@ -1013,7 +1011,7 @@ func TestSumComputeConfidenceIntervalForFloat64PostProcessing(t *testing.T) {
 	}
 }
 
-// Tests that ComputeConfidenceInterval returns a correct interval for a given sum.
+// Tests that ComputeConfidenceInterval for int64 returns a correct interval for a given sum.
 func TestSumComputeConfidenceIntervalForInt64Computation(t *testing.T) {
 	for _, tc := range []struct {
 		desc string
@@ -1049,9 +1047,8 @@ func TestSumComputeConfidenceIntervalForInt64Computation(t *testing.T) {
 	}
 }
 
-// Tests that ComputeConfidenceInterval returns a correct interval for a given sum.
+// Tests that ComputeConfidenceInterval for float64 returns a correct interval for a given sum.
 func TestSumComputeConfidenceIntervalForFloat64Computation(t *testing.T) {
-	// Tests returned confidence intervals using Laplace or Gaussian for a given sum.
 	for _, tc := range []struct {
 		desc string
 		opt  *BoundedSumFloat64Options
@@ -1086,7 +1083,7 @@ func TestSumComputeConfidenceIntervalForFloat64Computation(t *testing.T) {
 	}
 }
 
-// Tests that calling ComputeConfidenceInterval without calling Result() produces an error.
+// Tests that calling ComputeConfidenceInterval for int64 without calling Result() produces an error.
 func TestSumComputeConfidenceIntervalCannotBeCalledBeforeResultForInt64(t *testing.T) {
 	c := getNoiselessBSI()
 	_, err := c.ComputeConfidenceInterval(0.1)
@@ -1095,7 +1092,7 @@ func TestSumComputeConfidenceIntervalCannotBeCalledBeforeResultForInt64(t *testi
 	}
 }
 
-// Tests that calling ComputeConfidenceInterval without calling Result() produces an error.
+// Tests that calling ComputeConfidenceInterval for float64 without calling Result() produces an error.
 func TestSumComputeConfidenceIntervalCannotBeCalledBeforeResultForFloat64(t *testing.T) {
 	c := getNoiselessBSF()
 	_, err := c.ComputeConfidenceInterval(0.1)

--- a/go/dpagg/sum_test.go
+++ b/go/dpagg/sum_test.go
@@ -903,14 +903,14 @@ func TestThresholdedResultFloat64(t *testing.T) {
 	}
 }
 
+// Tests ComputeConfidenceInterval that If both bounds are non-negative, then trim any negative interval. Similarly, if both
+// bounds are non-positive then trim any positive interval from the confidence interval.
 func TestSumComputeConfidenceIntervalForInt64PostProcessing(t *testing.T) {
-	// Tests If both bounds are non-negative, then trim any negative interval. Similarly, if both bounds are
-	// non-positive then trim any positive interval from the confidence interval.
 	// noNoise is set to skip initial argument checking.
 	noNoise := noNoise{}
 	for _, tc := range []struct {
 		opt     *BoundedSumInt64Options
-		confInt noise.ConfidenceInterval // Pre-processing.
+		confInt noise.ConfidenceInterval // Raw confidence interval.
 		want    noise.ConfidenceInterval // Post-processing.
 	}{
 		{
@@ -941,7 +941,7 @@ func TestSumComputeConfidenceIntervalForInt64PostProcessing(t *testing.T) {
 		},
 	} {
 		c := NewBoundedSumInt64(tc.opt)
-		// This makes Noise interface return the pre-processing confidence interval when ComputeConfidenceIntervalInt64 is called.
+		// This makes Noise interface return the raw confidence interval when ComputeConfidenceIntervalInt64 is called.
 		c.noise = getMockConfInt(tc.confInt)
 
 		c.Result()
@@ -958,14 +958,14 @@ func TestSumComputeConfidenceIntervalForInt64PostProcessing(t *testing.T) {
 	}
 }
 
+// Tests ComputeConfidenceInterval that If both bounds are non-negative, then trim any negative interval. Similarly, if both
+// bounds are non-positive then trim any positive interval from the confidence interval.
 func TestSumComputeConfidenceIntervalForFloat64PostProcessing(t *testing.T) {
-	// Tests If both bounds are non-negative, then trim any negative interval. Similarly, if both bounds are
-	// non-positive then trim any positive interval from the confidence interval.
 	// noNoise is set to skip initial argument checking.
 	noNoise := noNoise{}
 	for _, tc := range []struct {
 		opt     *BoundedSumFloat64Options
-		confInt noise.ConfidenceInterval // Pre-processing.
+		confInt noise.ConfidenceInterval // Raw confidence interval.
 		want    noise.ConfidenceInterval // Post-processing.
 	}{
 		{
@@ -996,7 +996,7 @@ func TestSumComputeConfidenceIntervalForFloat64PostProcessing(t *testing.T) {
 		},
 	} {
 		c := NewBoundedSumFloat64(tc.opt)
-		// This makes Noise interface return the pre-processing confidence interval when ComputeConfidenceIntervalFloat64 is called.
+		// This makes Noise interface return the raw confidence interval when ComputeConfidenceIntervalFloat64 is called.
 		c.noise = getMockConfInt(tc.confInt)
 
 		c.Result()
@@ -1013,8 +1013,8 @@ func TestSumComputeConfidenceIntervalForFloat64PostProcessing(t *testing.T) {
 	}
 }
 
+// Tests that ComputeConfidenceInterval returns a correct interval for a given sum.
 func TestSumComputeConfidenceIntervalForInt64Computation(t *testing.T) {
-	// Tests returned confidence intervals using Laplace or Gaussian for a given sum.
 	for _, tc := range []struct {
 		desc string
 		opt  *BoundedSumInt64Options
@@ -1049,6 +1049,7 @@ func TestSumComputeConfidenceIntervalForInt64Computation(t *testing.T) {
 	}
 }
 
+// Tests that ComputeConfidenceInterval returns a correct interval for a given sum.
 func TestSumComputeConfidenceIntervalForFloat64Computation(t *testing.T) {
 	// Tests returned confidence intervals using Laplace or Gaussian for a given sum.
 	for _, tc := range []struct {
@@ -1085,21 +1086,21 @@ func TestSumComputeConfidenceIntervalForFloat64Computation(t *testing.T) {
 	}
 }
 
-func TestSumComputeConfIntCannotBeCalledBeforeResultForInt64(t *testing.T) {
+// Tests that calling ComputeConfidenceInterval without calling Result() produces an error.
+func TestSumComputeConfidenceIntervalCannotBeCalledBeforeResultForInt64(t *testing.T) {
 	c := getNoiselessBSI()
-	// Calling ComputeConfidenceInterval without calling Result() first will produce an error.
 	_, err := c.ComputeConfidenceInterval(0.1)
 	if err == nil {
-		t.Errorf("TestSumComputeConfIntCannotBeCalledBeforeResultForInt64: No error was returned")
+		t.Errorf("TestSumComputeConfidenceIntervalCannotBeCalledBeforeResultForInt64: No error was returned, expected error")
 	}
 }
 
-func TestSumComputeConfIntCannotBeCalledBeforeResultForFloat64(t *testing.T) {
+// Tests that calling ComputeConfidenceInterval without calling Result() produces an error.
+func TestSumComputeConfidenceIntervalCannotBeCalledBeforeResultForFloat64(t *testing.T) {
 	c := getNoiselessBSF()
-	// Calling ComputeConfidenceInterval without calling Result() first will produce an error.
 	_, err := c.ComputeConfidenceInterval(0.1)
 	if err == nil {
-		t.Errorf("TestSumComputeConfIntCannotBeCalledBeforeResultForFloat64: No error was returned")
+		t.Errorf("TestSumComputeConfidenceIntervalCannotBeCalledBeforeResultForFloat64: No error was returned, expected error")
 	}
 }
 


### PR DESCRIPTION
- Add confidence interval to BoundedSum aggregation with tests.
- Add mock noise structs for testing with Confidence intervals.