### PR TITLE
Windows support continued

### DIFF
--- a/cc/algorithms/bounded-algorithm.h
+++ b/cc/algorithms/bounded-algorithm.h
@@ -97,11 +97,11 @@ class BoundedAlgorithmBuilder : public AlgorithmBuilder<T, Algorithm, Builder> {
     // Check if bounds are finite when a floating point type is used and bounds
     // have been set manually.
     if (BoundsAreSet() && std::is_floating_point<T>::value) {
-      if (!std::isfinite(lower_.value())) {
+      if (!std::isfinite(static_cast<double>(lower_.value()))) {
         return base::InvalidArgumentError(absl::StrCat(
             "Lower bound has to be finite but is ", lower_.value()));
       }
-      if (!std::isfinite(upper_.value())) {
+      if (!std::isfinite(static_cast<double>(upper_.value()))) {
         return base::InvalidArgumentError(absl::StrCat(
             "Upper bound has to be finite but is ", upper_.value()));
       }

--- a/cc/algorithms/util.h
+++ b/cc/algorithms/util.h
@@ -143,7 +143,7 @@ inline bool SafeCastFromDouble(const double in, T& out) {
     out = std::numeric_limits<T>::lowest();
     return true;
   }
-  out = T{in};
+  out = T{static_cast<T>(in)};
   return true;
 }
 


### PR DESCRIPTION
This is a continuation of PR #34 which addresses  #18 (and OpenMined/PyDP#112 of the downstream OpenMined PyDP project)

This PR fixes two minor cross platform issues. 

1. On windows the `cmath.h` library has issues with integer overloads and does not do implicit casts. Exmple from #34 "std::isnan on windows does not do an implicit cast to double and causes a compiler error: C2668 'fpclassify': ambiguous call to overloaded function"
This is fixed by a `static_cast` [see](https://github.com/google/differential-privacy/commit/d0b3d00462974ad5f6509ea65df27267013551c0)

2. The `cl.exe` windows compiler and linker don't support a narrowing cast when using initializer lists. This was fixed by a static_cast [here](https://github.com/google/differential-privacy/commit/6f96b4c80d4ca1814ed0a0a9e0ac82692597447d)

These are small changes however, I think that we should add a CI step or job that builds this library on windows so that they can be caught earlier and would not require minimal PRs such as this. I would be happy to add such a step or job to the CI system. As far as I can see this is done internally as there are no ci configs of gh actions. 
If such a CI step was added then these minor cross platform differences can be flagged earlier and the downstream windows users will not need to submit patches.

Feel free to reach out to me here or on the openmined slack (at-benj)