### PR TITLE
Golang/Java: Multiple fixes and improvements

### DIFF
--- a/go/dpagg/count_test.go
+++ b/go/dpagg/count_test.go
@@ -396,12 +396,12 @@ func TestCountComputeConfidenceIntervalComputation(t *testing.T) {
 	}{
 		{
 			desc: "Gaussian",
-			opt:  &CountOptions{Epsilon: 0.1, Delta: 0.1, Noise: getNoiselessConfInt(noise.Gaussian())},
+			opt:  &CountOptions{Epsilon: 0.1, Delta: 0.1, Noise: noNoise{noise.Gaussian()}},
 			want: noise.ConfidenceInterval{LowerBound: 8, UpperBound: 12},
 		},
 		{
 			desc: "Laplace",
-			opt:  &CountOptions{Epsilon: 0.1, Noise: getNoiselessConfInt(noise.Laplace())},
+			opt:  &CountOptions{Epsilon: 0.1, Noise: noNoise{noise.Laplace()}},
 			want: noise.ConfidenceInterval{LowerBound: 3, UpperBound: 17},
 		},
 	} {

--- a/go/dpagg/dpagg_test.go
+++ b/go/dpagg/dpagg_test.go
@@ -55,18 +55,24 @@ func (noNoise) Threshold(_ int64, _, _, _, _ float64) float64 {
 	return 5
 }
 
+// If noNoise is not initialized with a noise distribution, confidence interval functions will return a default confidence interval i.e [0,0].
+// Otherwise, it will forward the function call to the embedded noise distribution.
+//
+// Note that initializing noNoise with a noise distribution doesn't apply to addNoise functions since they are overridden.
 func (nN noNoise) ComputeConfidenceIntervalInt64(noisedX, l0, lInf int64, eps, del, alpha float64) (noise.ConfidenceInterval, error) {
+	if nN.Noise == nil {
+		return noise.ConfidenceInterval{}, nil
+	}
 	confInt, err := nN.Noise.ComputeConfidenceIntervalInt64(noisedX, l0, lInf, eps, del, alpha)
 	return confInt, err
 }
 
 func (nN noNoise) ComputeConfidenceIntervalFloat64(noisedX float64, l0 int64, lInf, eps, del, alpha float64) (noise.ConfidenceInterval, error) {
+	if nN.Noise == nil {
+		return noise.ConfidenceInterval{}, nil
+	}
 	confInt, err := nN.Noise.ComputeConfidenceIntervalFloat64(noisedX, l0, lInf, eps, del, alpha)
 	return confInt, err
-}
-
-func getNoiselessConfInt(noise noise.Noise) noise.Noise {
-	return noNoise{noise}
 }
 
 // mockConfInt is a Noise instance that returns a pre-set confidence interval.

--- a/go/dpagg/sum.go
+++ b/go/dpagg/sum.go
@@ -262,7 +262,7 @@ func (bs *BoundedSumInt64) ThresholdedResult(thresholdDelta float64) *int64 {
 // See https://github.com/google/differential-privacy/tree/main/common_docs/confidence_intervals.md.
 func (bs *BoundedSumInt64) ComputeConfidenceInterval(alpha float64) (noise.ConfidenceInterval, error) {
 	if !bs.resultReturned {
-		return noise.ConfidenceInterval{}, fmt.Errorf("You need to call Result() before calling ComputeConfidenceInterval()")
+		return noise.ConfidenceInterval{}, fmt.Errorf("Result() must be called before calling ComputeConfidenceInterval()")
 	}
 	confInt, err := bs.noise.ComputeConfidenceIntervalInt64(bs.noisedSum, bs.l0Sensitivity, bs.lInfSensitivity, bs.epsilon, bs.delta, alpha)
 	if err != nil {

--- a/go/dpagg/sum_test.go
+++ b/go/dpagg/sum_test.go
@@ -1020,12 +1020,12 @@ func TestSumComputeConfidenceIntervalForInt64Computation(t *testing.T) {
 	}{
 		{
 			desc: "Gaussian",
-			opt:  &BoundedSumInt64Options{Epsilon: 0.1, Delta: 0.1, Lower: 0, Upper: 5, Noise: getNoiselessConfInt(noise.Gaussian())},
+			opt:  &BoundedSumInt64Options{Epsilon: 0.1, Delta: 0.1, Lower: 0, Upper: 5, Noise: noNoise{noise.Gaussian()}},
 			want: noise.ConfidenceInterval{LowerBound: 40, UpperBound: 60},
 		},
 		{
 			desc: "Laplace",
-			opt:  &BoundedSumInt64Options{Epsilon: 0.1, Lower: 0, Upper: 5, Noise: getNoiselessConfInt(noise.Laplace())},
+			opt:  &BoundedSumInt64Options{Epsilon: 0.1, Lower: 0, Upper: 5, Noise: noNoise{noise.Laplace()}},
 			want: noise.ConfidenceInterval{LowerBound: 15, UpperBound: 85},
 		},
 	} {
@@ -1057,13 +1057,13 @@ func TestSumComputeConfidenceIntervalForFloat64Computation(t *testing.T) {
 	}{
 		{
 			desc:      "Gaussian",
-			opt:       &BoundedSumFloat64Options{Epsilon: 0.1, Delta: 0.1, Lower: 0, Upper: 5, Noise: getNoiselessConfInt(noise.Gaussian())},
+			opt:       &BoundedSumFloat64Options{Epsilon: 0.1, Delta: 0.1, Lower: 0, Upper: 5, Noise: noNoise{noise.Gaussian()}},
 			want:      noise.ConfidenceInterval{LowerBound: 15.898893, UpperBound: 35.101107},
 			tolerance: 1e-3,
 		},
 		{
 			desc:      "Laplace",
-			opt:       &BoundedSumFloat64Options{Epsilon: 0.1, Lower: 0, Upper: 5, Noise: getNoiselessConfInt(noise.Laplace())},
+			opt:       &BoundedSumFloat64Options{Epsilon: 0.1, Lower: 0, Upper: 5, Noise: noNoise{noise.Laplace()}},
 			want:      noise.ConfidenceInterval{LowerBound: 0.0, UpperBound: 60.157359},
 			tolerance: 1e-6,
 		},
@@ -1075,6 +1075,7 @@ func TestSumComputeConfidenceIntervalForFloat64Computation(t *testing.T) {
 		c.Result()
 		got, _ := c.ComputeConfidenceInterval(0.5)
 
+		// TODO: Replace with appropriate approxEqual function.
 		if math.Abs(got.LowerBound-tc.want.LowerBound) > tc.tolerance*math.Max(got.LowerBound, tc.want.LowerBound) {
 			t.Errorf("TestSumComputeConfidenceIntervalForFloat64Computation(Noise: %s)=%0.10f, want %0.10f, LowerBounds are not equal",
 				tc.desc, got.LowerBound, tc.want.LowerBound)

--- a/go/dpagg/sum_test.go
+++ b/go/dpagg/sum_test.go
@@ -1050,19 +1050,22 @@ func TestSumComputeConfidenceIntervalForInt64Computation(t *testing.T) {
 // Tests that ComputeConfidenceInterval for float64 returns a correct interval for a given sum.
 func TestSumComputeConfidenceIntervalForFloat64Computation(t *testing.T) {
 	for _, tc := range []struct {
-		desc string
-		opt  *BoundedSumFloat64Options
-		want noise.ConfidenceInterval
+		desc      string
+		opt       *BoundedSumFloat64Options
+		want      noise.ConfidenceInterval
+		tolerance float64
 	}{
 		{
-			desc: "Gaussian",
-			opt:  &BoundedSumFloat64Options{Epsilon: 0.1, Delta: 0.1, Lower: 0, Upper: 5, Noise: getNoiselessConfInt(noise.Gaussian())},
-			want: noise.ConfidenceInterval{LowerBound: 15.8964252365, UpperBound: 35.1035747635},
+			desc:      "Gaussian",
+			opt:       &BoundedSumFloat64Options{Epsilon: 0.1, Delta: 0.1, Lower: 0, Upper: 5, Noise: getNoiselessConfInt(noise.Gaussian())},
+			want:      noise.ConfidenceInterval{LowerBound: 15.898893, UpperBound: 35.101107},
+			tolerance: 1e-3,
 		},
 		{
-			desc: "Laplace",
-			opt:  &BoundedSumFloat64Options{Epsilon: 0.1, Lower: 0, Upper: 5, Noise: getNoiselessConfInt(noise.Laplace())},
-			want: noise.ConfidenceInterval{LowerBound: 0.0000000000, UpperBound: 60.1573590280},
+			desc:      "Laplace",
+			opt:       &BoundedSumFloat64Options{Epsilon: 0.1, Lower: 0, Upper: 5, Noise: getNoiselessConfInt(noise.Laplace())},
+			want:      noise.ConfidenceInterval{LowerBound: 0.0, UpperBound: 60.157359},
+			tolerance: 1e-6,
 		},
 	} {
 		c := NewBoundedSumFloat64(tc.opt)
@@ -1072,11 +1075,11 @@ func TestSumComputeConfidenceIntervalForFloat64Computation(t *testing.T) {
 		c.Result()
 		got, _ := c.ComputeConfidenceInterval(0.5)
 
-		if !ApproxEqual(got.LowerBound, tc.want.LowerBound) {
+		if math.Abs(got.LowerBound-tc.want.LowerBound) > tc.tolerance*math.Max(got.LowerBound, tc.want.LowerBound) {
 			t.Errorf("TestSumComputeConfidenceIntervalForFloat64Computation(Noise: %s)=%0.10f, want %0.10f, LowerBounds are not equal",
 				tc.desc, got.LowerBound, tc.want.LowerBound)
 		}
-		if !ApproxEqual(got.UpperBound, tc.want.UpperBound) {
+		if math.Abs(got.UpperBound-tc.want.UpperBound) > tc.tolerance*math.Max(got.UpperBound, tc.want.UpperBound) {
 			t.Errorf("TestSumComputeConfidenceIntervalForFloat64Computation(Noise: %s)=%0.10f, want %0.10f, UpperBounds are not equal",
 				tc.desc, got.UpperBound, tc.want.UpperBound)
 		}

--- a/go/noise/gaussian_noise.go
+++ b/go/noise/gaussian_noise.go
@@ -123,14 +123,22 @@ func (gaussian) DeltaForThreshold(l0Sensitivity int64, lInfSensitivity, epsilon,
 //
 // See https://github.com/google/differential-privacy/tree/main/common_docs/confidence_intervals.md.
 func (gaussian) ComputeConfidenceIntervalInt64(noisedX, l0Sensitivity, lInfSensitivity int64, epsilon, delta, alpha float64) (ConfidenceInterval, error) {
-	err := checkArgsConfidenceIntervalGaussian("computeConfidenceIntervalInt64", l0Sensitivity, float64(lInfSensitivity), epsilon, delta, alpha)
+	err := checkArgsConfidenceIntervalGaussian("ComputeConfidenceIntervalInt64 (gaussian)", l0Sensitivity, float64(lInfSensitivity), epsilon, delta, alpha)
 	if err != nil {
 		err := fmt.Errorf("ComputeConfidenceIntervalInt64(l0sensitivity %d, lInfSensitivity %d, epsilon %f, delta %e, alpha %f) checks failed with %v",
 			l0Sensitivity, lInfSensitivity, epsilon, delta, alpha, err)
 		return ConfidenceInterval{}, err
 	}
 	sigma := SigmaForGaussian(l0Sensitivity, float64(lInfSensitivity), epsilon, delta)
-	return computeConfidenceIntervalGaussian(float64(noisedX), sigma, alpha).roundToInt64(), nil
+	// Computing the confidence interval around zero rather than nosiedX helps represent the
+	// interval bounds more accurately. The reason is that the resolution of float64 values is most
+	// fine grained around zero.
+	confIntAroundZero := computeConfidenceIntervalGaussian(0, sigma, alpha).roundToInt64()
+	// Adding noisedX after converting the interval bounds to int64 ensures that no precision is lost
+	// due to the coarse resolution of float64 values for large instances of noisedX.
+	lowerBound := nextSmallerFloat64(int64(confIntAroundZero.LowerBound) + noisedX)
+	upperBound := nextLargerFloat64(int64(confIntAroundZero.UpperBound) + noisedX)
+	return ConfidenceInterval{LowerBound: lowerBound, UpperBound: upperBound}, nil
 }
 
 // ComputeConfidenceIntervalFloat64 computes a confidence interval that contains the raw value x from which float64
@@ -138,7 +146,7 @@ func (gaussian) ComputeConfidenceIntervalInt64(noisedX, l0Sensitivity, lInfSensi
 //
 // See https://github.com/google/differential-privacy/tree/main/common_docs/confidence_intervals.md.
 func (gaussian) ComputeConfidenceIntervalFloat64(noisedX float64, l0Sensitivity int64, lInfSensitivity, epsilon, delta, alpha float64) (ConfidenceInterval, error) {
-	err := checkArgsConfidenceIntervalGaussian("ComputeConfidenceIntervalFloat64", l0Sensitivity, lInfSensitivity, epsilon, delta, alpha)
+	err := checkArgsConfidenceIntervalGaussian("ComputeConfidenceIntervalFloat64 (gaussian)", l0Sensitivity, lInfSensitivity, epsilon, delta, alpha)
 	if err != nil {
 		err = fmt.Errorf("ComputeConfidenceIntervalFloat64(l0sensitivity %d, lInfSensitivity %f, epsilon %f, delta %e, alpha %f) checks failed with %v",
 			l0Sensitivity, lInfSensitivity, epsilon, delta, alpha, err)
@@ -184,10 +192,15 @@ func addGaussian(x, sigma float64) float64 {
 // computeConfidenceIntervalGaussian computes a confidence interval that contains the raw value x from which
 // float64 noisedX is computed with a probability equal to 1 - alpha with the given sigma.
 func computeConfidenceIntervalGaussian(noisedX, sigma, alpha float64) ConfidenceInterval {
-	z := inverseCDFGaussian(sigma, alpha/2) // z will hold a negative value.
-	FloatLowerBound := noisedX + z
-	FloatUpperBound := noisedX - z
-	return ConfidenceInterval{LowerBound: FloatLowerBound, UpperBound: FloatUpperBound}
+	z := inverseCDFGaussian(sigma, alpha/2)
+	// Because of the symmetry of the Gaussian distribution,
+	// -z corresponds to the (1 - alpha/2)-quantile of the distribution,
+	// meaning that the interval [z, -z] contains 1-alpha of the probability mass.
+	// Deriving the (1 - alpha/2)-quantile from the (alpha/2)-quantile and not vice versa is a
+	// deliberate choice. The reason is that alpha tends to be very small.
+	// Consequently, alpha/2 is more accurately representable as a float64 than 1 - alpha/2,
+	// facilitating numerical computations.
+	return ConfidenceInterval{LowerBound: noisedX + z, UpperBound: noisedX - z}
 }
 
 // inverseCDFGaussian computes the quantile z satisfying Pr[Y <= z] = p for a random variable Y that is Gaussian

--- a/go/noise/gaussian_noise_test.go
+++ b/go/noise/gaussian_noise_test.go
@@ -490,7 +490,7 @@ func TestInverseCDFGaussian(t *testing.T) {
 	} {
 		Zc := inverseCDFGaussian(tc.sigma, tc.p)
 		if !approxEqual(Zc, tc.want) {
-			t.Errorf("TestInverseCDFGaussian(%f, %f) = %0.10f, want %0.10f, desc: %s", tc.sigma, tc.p, Zc, tc.want, tc.desc)
+			t.Errorf("inverseCDFGaussian(%f, %f) = %0.10f, want %0.10f, desc: %s", tc.sigma, tc.p, Zc, tc.want, tc.desc)
 		}
 	}
 }
@@ -564,11 +564,11 @@ func TestComputeConfidenceIntervalGaussian(t *testing.T) {
 	} {
 		result := computeConfidenceIntervalGaussian(tc.noisedX, tc.sigma, tc.alpha)
 		if !approxEqual(result.LowerBound, tc.want.LowerBound) {
-			t.Errorf("TestComputeConfidenceIntervalGaussian(%f, %f, %f)=%0.10f, want %0.10f, desc %s, LowerBounds are not equal",
+			t.Errorf("computeConfidenceIntervalGaussian(%f, %f, %f)=%0.10f, want %0.10f, desc %s, LowerBounds are not equal",
 				tc.noisedX, tc.alpha, tc.sigma, result.LowerBound, tc.want.LowerBound, tc.desc)
 		}
 		if !approxEqual(result.UpperBound, tc.want.UpperBound) {
-			t.Errorf("TestComputeConfidenceIntervalGaussian(%f, %f, %f)=%0.10f, want %0.10f, desc %s, UpperBounds are not equal",
+			t.Errorf("computeConfidenceIntervalGaussian(%f, %f, %f)=%0.10f, want %0.10f, desc %s, UpperBounds are not equal",
 				tc.noisedX, tc.alpha, tc.sigma, result.UpperBound, tc.want.UpperBound, tc.desc)
 		}
 	}
@@ -647,21 +647,20 @@ func TestComputeConfidenceIntervalInt64Gaussian(t *testing.T) {
 	} {
 		got, err := gauss.ComputeConfidenceIntervalInt64(tc.noisedX, tc.l0Sensitivity, tc.lInfSensitivity, tc.epsilon, tc.delta, tc.alpha)
 		if err != nil {
-			t.Errorf("ComputeConfidenceIntervalInt64Gaussian: when %s got err %v", tc.desc, err)
+			t.Errorf("ComputeConfidenceIntervalInt64: when %s got err %v", tc.desc, err)
 		}
 		if got.LowerBound != tc.want.LowerBound {
-			t.Errorf("TestComputeConfidenceIntervalInt64Gaussian(%d, %d, %d, %f, %f, %f)=%f, want %f, desc %s, LowerBounds are not equal",
+			t.Errorf("ComputeConfidenceIntervalInt64(%d, %d, %d, %f, %f, %f)=%f, want %f, desc %s, LowerBounds are not equal",
 				tc.noisedX, tc.l0Sensitivity, tc.lInfSensitivity, tc.epsilon, tc.delta, tc.alpha, got.LowerBound, tc.want.LowerBound, tc.desc)
 		}
 		if got.UpperBound != tc.want.UpperBound {
-			t.Errorf("TestComputeConfidenceIntervalInt64Gaussian(%d, %d, %d, %f, %f, %f)=%f, want %f, desc %s, UpperBounds are not equal",
+			t.Errorf("ComputeConfidenceIntervalInt64(%d, %d, %d, %f, %f, %f)=%f, want %f, desc %s, UpperBounds are not equal",
 				tc.noisedX, tc.l0Sensitivity, tc.lInfSensitivity, tc.epsilon, tc.delta, tc.alpha, got.UpperBound, tc.want.UpperBound, tc.desc)
 		}
 	}
 }
 
 func TestComputeConfidenceIntervalInt64GaussianArgumentCheck(t *testing.T) {
-	// Test
 	for _, tc := range []struct {
 		desc                                    string
 		noisedX, l0Sensitivity, lInfSensitivity int64
@@ -820,20 +819,14 @@ func TestComputeConfidenceIntervalInt64GaussianArgumentCheck(t *testing.T) {
 			alpha:           math.NaN(),
 		},
 	} {
-		got, err := gauss.ComputeConfidenceIntervalInt64(tc.noisedX, tc.l0Sensitivity, tc.lInfSensitivity, tc.epsilon, tc.delta, tc.alpha)
+		_, err := gauss.ComputeConfidenceIntervalInt64(tc.noisedX, tc.l0Sensitivity, tc.lInfSensitivity, tc.epsilon, tc.delta, tc.alpha)
 		if err == nil {
-			t.Errorf("ComputeConfidenceIntervalInt64Gaussian: when %s no error was returned, expected error", tc.desc)
-		}
-		// Checks default confidence interval is returned when err is generated.
-		if (got != ConfidenceInterval{}) {
-			t.Errorf("TestComputeConfidenceIntervalInt64GaussianArgumentCheck(%d, %d, %d, %f, %f)=[LowerBound: %0.10f, UpperBound: %0.10f], want [LowerBound: 0.0, UpperBound: 0.0]",
-				tc.noisedX, tc.l0Sensitivity, tc.lInfSensitivity, tc.epsilon, tc.alpha, got.LowerBound, got.UpperBound)
+			t.Errorf("ComputeConfidenceIntervalInt64: when %s no error was returned, expected error", tc.desc)
 		}
 	}
 }
 
 func TestComputeConfidenceIntervalFloat64GaussianArgumentCheck(t *testing.T) {
-	// Test
 	for _, tc := range []struct {
 		desc                                   string
 		noisedX                                float64
@@ -995,14 +988,9 @@ func TestComputeConfidenceIntervalFloat64GaussianArgumentCheck(t *testing.T) {
 			alpha:           0.2,
 		},
 	} {
-		got, err := gauss.ComputeConfidenceIntervalFloat64(tc.noisedX, tc.l0Sensitivity, tc.lInfSensitivity, tc.epsilon, tc.delta, tc.alpha)
+		_, err := gauss.ComputeConfidenceIntervalFloat64(tc.noisedX, tc.l0Sensitivity, tc.lInfSensitivity, tc.epsilon, tc.delta, tc.alpha)
 		if err == nil {
-			t.Errorf("ComputeConfidenceIntervalFloat64Gaussian: when %s no error was returned, expected error", tc.desc)
-		}
-		// Checks default confidence interval is returned when err is generated.
-		if (got != ConfidenceInterval{}) {
-			t.Errorf("TestComputeConfidenceIntervalFloat64GaussianArgumentCheck(%f, %d, %f, %f, %f)=[LowerBound: %0.10f, UpperBound: %0.10f], want [LowerBound: 0.0, UpperBound: 0.0]",
-				tc.noisedX, tc.l0Sensitivity, tc.lInfSensitivity, tc.epsilon, tc.alpha, got.LowerBound, got.UpperBound)
+			t.Errorf("ComputeConfidenceIntervalFloat64: when %s no error was returned, expected error", tc.desc)
 		}
 	}
 }

--- a/go/noise/gaussian_noise_test.go
+++ b/go/noise/gaussian_noise_test.go
@@ -117,7 +117,7 @@ func TestGaussianStatistics(t *testing.T) {
 	}
 }
 
-func TestSymmetricBinomialStatisitcs(t *testing.T) {
+func TestSymmetricBinomialStatistics(t *testing.T) {
 	const numberOfSamples = 125000
 	for _, tc := range []struct {
 		sqrtN  float64
@@ -278,7 +278,7 @@ func TestSigmaForGaussianInvertsDeltaForGaussian(t *testing.T) {
 	// tolerance. This validates that the function
 	//   delta ↦ SigmaForGaussian(l2Sensitivity, epsilon, delta)
 	// is an approximate inverse function of
-	//   sigma ↦ DeltaForGuassian(sigma, l2Sensitivity, epsilon).
+	//   sigma ↦ DeltaForGaussian(sigma, l2Sensitivity, epsilon).
 
 	for _, tc := range []struct {
 		desc            string
@@ -445,52 +445,52 @@ func TestInverseCDFGaussian(t *testing.T) {
 	}{
 
 		{
-			desc:  "Abitrary input test",
-			sigma: 1,
+			desc:  "Arbitrary input test",
+			sigma: 1.0,
 			p:     0.05,
-			want:  -1.64485362695,
+			want:  -1.6448536,
 		},
 		{
-			desc:  "Abitrary input test",
+			desc:  "Arbitrary input test",
 			sigma: 2.342354,
 			p:     0.0240299,
-			want:  -4.630457396977453,
+			want:  -4.6304574,
 		},
 		{
-			desc:  "Abitrary input test",
+			desc:  "Arbitrary input test",
 			sigma: 0.3,
-			p:     0.075345892435835346586,
-			want:  -0.431127673071454,
+			p:     0.07534589,
+			want:  -0.43112767,
 		},
 		{
 			desc:  "Edge case test with low alpha",
 			sigma: 0.356,
 			p:     10e-10,
-			want:  -2.1352192973427364,
+			want:  -2.1352193,
 		},
 		{
 			desc:  "Edge case test with high alpha",
 			sigma: 0.84,
 			p:     1 - 10e-10,
-			want:  5.0381578964653757,
+			want:  5.0381579,
 		},
 		// For p = 0.5, the result should be the mean regardless of sigma.
 		{
 			desc:  "Test with p = 0.5",
 			sigma: 0.3,
 			p:     0.5,
-			want:  0,
+			want:  0.0,
 		},
 		{
 			desc:  "Test with p = 0.5",
 			sigma: 0.8235243,
 			p:     0.5,
-			want:  0,
+			want:  0.0,
 		},
 	} {
 		Zc := inverseCDFGaussian(tc.sigma, tc.p)
-		if !(approxEqual(Zc, tc.want)) {
-			t.Errorf(" TestInverseCDFGaussian(%f, %f) = %0.16f, want %0.16f, desc: %s", tc.sigma, tc.p, Zc, tc.want, tc.desc)
+		if !approxEqual(Zc, tc.want) {
+			t.Errorf("TestInverseCDFGaussian(%f, %f) = %0.10f, want %0.10f, desc: %s", tc.sigma, tc.p, Zc, tc.want, tc.desc)
 		}
 	}
 }
@@ -505,55 +505,70 @@ func TestComputeConfidenceIntervalGaussian(t *testing.T) {
 		want    ConfidenceInterval
 	}{
 		{
-			desc:    "computeConfidenceIntervalGaussian arbitrary input test",
-			noisedX: 21,
-			sigma:   1,
+			desc:    "Arbitrary input test",
+			noisedX: 21.0,
+			sigma:   1.0,
 			alpha:   0.05,
-			want:    ConfidenceInterval{19.0400360155, 22.9599639845},
+			want:    ConfidenceInterval{19.040036, 22.959964},
 		},
 		{
-			desc:    "computeConfidenceIntervalGaussian arbitrary input test",
+			desc:    "Arbitrary input test",
 			noisedX: 40.003,
 			sigma:   0.333,
 			alpha:   1 - 0.888,
-			want:    ConfidenceInterval{39.473773903501886, 40.532226096498114},
+			want:    ConfidenceInterval{39.473774, 40.532226},
 		},
 		{
-			desc:    "computeConfidenceIntervalGaussian arbitrary input test",
+			desc:    "Arbitrary input test",
 			noisedX: 0.1,
 			sigma:   0.292929,
 			alpha:   1 - 0.888,
-			want:    ConfidenceInterval{-0.36554255621950726, 0.5655425562195072},
+			want:    ConfidenceInterval{-0.36554256, 0.56554256},
 		},
 		{
-			desc:    "computeConfidenceIntervalGaussian arbitrary input test",
+			desc:    "Arbitrary input test",
 			noisedX: 99.98989898,
 			sigma:   15423235,
 			alpha:   1 - 0.111,
-			want:    ConfidenceInterval{-2.1525159435946424e+06, 2.1527159233926027e+06},
+			want:    ConfidenceInterval{-2.1525159e+06, 2.1527159e+06},
 		},
 		{
 			desc:    "Low confidence level",
-			noisedX: 100,
-			sigma:   10,
+			noisedX: 100.0,
+			sigma:   10.0,
 			alpha:   1 - 1e-10,
-			want:    ConfidenceInterval{99.9999999987466878792474745, 100.0000000012533121207525255},
+			want:    ConfidenceInterval{99.999999, 100.00000},
 		},
 		{
 			desc:    "High confidence level",
-			noisedX: 100,
-			sigma:   10,
+			noisedX: 100.0,
+			sigma:   10.0,
 			alpha:   1e-10,
-			want:    ConfidenceInterval{35.3304891275948307338694576, 164.6695108724051692661305424},
+			want:    ConfidenceInterval{35.330489, 164.66951},
+		},
+		// Testing that bounds are accurate for abs(bound) < 2^53
+		{
+			desc:    "Large positive noisedX",
+			noisedX: 38475693.0,
+			sigma:   2.8469244,
+			alpha:   0.1,
+			want:    ConfidenceInterval{38475688.3, 38475697.7},
+		},
+		{
+			desc:    "Large negative noisedX",
+			noisedX: -38475693.0,
+			sigma:   2.8469244,
+			alpha:   0.1,
+			want:    ConfidenceInterval{-38475697.7, -38475688.3},
 		},
 	} {
 		result := computeConfidenceIntervalGaussian(tc.noisedX, tc.sigma, tc.alpha)
 		if !approxEqual(result.LowerBound, tc.want.LowerBound) {
-			t.Errorf("TestComputeConfidenceIntervalGaussian(%f, %f, %f)=%0.10f, want %0.10f, desc %s, LowerBound is not equal",
+			t.Errorf("TestComputeConfidenceIntervalGaussian(%f, %f, %f)=%0.10f, want %0.10f, desc %s, LowerBounds are not equal",
 				tc.noisedX, tc.alpha, tc.sigma, result.LowerBound, tc.want.LowerBound, tc.desc)
 		}
 		if !approxEqual(result.UpperBound, tc.want.UpperBound) {
-			t.Errorf("TestConfidenceIntervalGaussian(%f, %f, %f)=%0.10f, want %0.10f, desc %s, UpperBound is not equal",
+			t.Errorf("TestComputeConfidenceIntervalGaussian(%f, %f, %f)=%0.10f, want %0.10f, desc %s, UpperBounds are not equal",
 				tc.noisedX, tc.alpha, tc.sigma, result.UpperBound, tc.want.UpperBound, tc.desc)
 		}
 	}
@@ -565,7 +580,6 @@ func TestComputeConfidenceIntervalInt64Gaussian(t *testing.T) {
 		noisedX, l0Sensitivity, lInfSensitivity int64
 		epsilon, delta, alpha                   float64
 		want                                    ConfidenceInterval
-		wantErr                                 bool
 	}{
 		{
 			desc:            "Arbitrary test",
@@ -576,7 +590,6 @@ func TestComputeConfidenceIntervalInt64Gaussian(t *testing.T) {
 			delta:           0.1,
 			alpha:           0.2,
 			want:            ConfidenceInterval{8, 132},
-			wantErr:         false,
 		},
 		{
 			desc:            "Arbitrary test",
@@ -587,31 +600,73 @@ func TestComputeConfidenceIntervalInt64Gaussian(t *testing.T) {
 			delta:           0.9,
 			alpha:           0.152145599,
 			want:            ConfidenceInterval{-5, 7},
-			wantErr:         false,
 		},
-		// Testing checkArgsConfidenceIntervalGaussian.
 		{
 			desc:            "Arbitrary test with high alpha",
-			noisedX:         70.0,
+			noisedX:         70,
 			l0Sensitivity:   5,
 			lInfSensitivity: 36,
 			epsilon:         0.8,
 			delta:           0.8,
 			alpha:           1 - 7.856382354e-10,
 			want:            ConfidenceInterval{70, 70},
-			wantErr:         false,
 		},
 		{
 			desc:            "Arbitrary test with low alpha",
-			noisedX:         70.0,
+			noisedX:         70,
 			l0Sensitivity:   5,
 			lInfSensitivity: 36,
 			epsilon:         0.8,
 			delta:           0.8,
 			alpha:           7.856382354e-10,
 			want:            ConfidenceInterval{-97, 237},
-			wantErr:         false,
 		},
+		// Tests for nextSmallerFloat64 and nextLargerFloat64.
+		{
+			desc: "Large positive noisedX",
+			// Distance to neighbouring float64 values is greater than half the size of the confidence interval.
+			noisedX:         (1 << 58),
+			l0Sensitivity:   1,
+			lInfSensitivity: 1,
+			epsilon:         0.1,
+			delta:           0.1,
+			alpha:           0.1,
+			want:            ConfidenceInterval{math.Nextafter(1<<58, math.Inf(-1)), math.Nextafter(1<<58, math.Inf(1))},
+		},
+		{
+			desc: "Large negative noisedX",
+			// Distance to neighbouring float64 values is greater than half the size of the confidence interval.
+			noisedX:         -(1 << 58),
+			l0Sensitivity:   1,
+			lInfSensitivity: 1,
+			epsilon:         0.1,
+			delta:           0.1,
+			alpha:           0.1,
+			want:            ConfidenceInterval{math.Nextafter(-1<<58, math.Inf(-1)), math.Nextafter(-1<<58, math.Inf(1))},
+		},
+	} {
+		got, err := gauss.ComputeConfidenceIntervalInt64(tc.noisedX, tc.l0Sensitivity, tc.lInfSensitivity, tc.epsilon, tc.delta, tc.alpha)
+		if err != nil {
+			t.Errorf("ComputeConfidenceIntervalInt64Gaussian: when %s got err %v", tc.desc, err)
+		}
+		if got.LowerBound != tc.want.LowerBound {
+			t.Errorf("TestComputeConfidenceIntervalInt64Gaussian(%d, %d, %d, %f, %f, %f)=%f, want %f, desc %s, LowerBounds are not equal",
+				tc.noisedX, tc.l0Sensitivity, tc.lInfSensitivity, tc.epsilon, tc.delta, tc.alpha, got.LowerBound, tc.want.LowerBound, tc.desc)
+		}
+		if got.UpperBound != tc.want.UpperBound {
+			t.Errorf("TestComputeConfidenceIntervalInt64Gaussian(%d, %d, %d, %f, %f, %f)=%f, want %f, desc %s, UpperBounds are not equal",
+				tc.noisedX, tc.l0Sensitivity, tc.lInfSensitivity, tc.epsilon, tc.delta, tc.alpha, got.UpperBound, tc.want.UpperBound, tc.desc)
+		}
+	}
+}
+
+func TestComputeConfidenceIntervalInt64GaussianArgumentCheck(t *testing.T) {
+	// Test
+	for _, tc := range []struct {
+		desc                                    string
+		noisedX, l0Sensitivity, lInfSensitivity int64
+		epsilon, delta, alpha                   float64
+	}{
 		{
 			desc:            "Testing alpha bigger than 1",
 			noisedX:         1,
@@ -620,8 +675,6 @@ func TestComputeConfidenceIntervalInt64Gaussian(t *testing.T) {
 			epsilon:         0.5,
 			delta:           0.9,
 			alpha:           1.2, // alpha should not be larger than 1.
-			want:            ConfidenceInterval{},
-			wantErr:         true,
 		},
 		{
 			desc:            "Testing negative alpha",
@@ -631,8 +684,6 @@ func TestComputeConfidenceIntervalInt64Gaussian(t *testing.T) {
 			epsilon:         0.5,
 			delta:           0.9,
 			alpha:           -5, // alpha should not be smaller than 0.
-			want:            ConfidenceInterval{},
-			wantErr:         true,
 		},
 		{
 			desc:            "Testing negative l0Sensitivity",
@@ -642,8 +693,6 @@ func TestComputeConfidenceIntervalInt64Gaussian(t *testing.T) {
 			epsilon:         0.5,
 			delta:           0.9,
 			alpha:           0.2,
-			want:            ConfidenceInterval{},
-			wantErr:         true,
 		},
 		{
 			desc:            "Testing zero l0Sensitivity",
@@ -653,8 +702,6 @@ func TestComputeConfidenceIntervalInt64Gaussian(t *testing.T) {
 			epsilon:         0.5,
 			delta:           0.9,
 			alpha:           0.2,
-			want:            ConfidenceInterval{},
-			wantErr:         true,
 		},
 		{
 			desc:            "Testing negative lInfSensitivity",
@@ -664,8 +711,6 @@ func TestComputeConfidenceIntervalInt64Gaussian(t *testing.T) {
 			epsilon:         0.5,
 			delta:           0.9,
 			alpha:           0.2,
-			want:            ConfidenceInterval{},
-			wantErr:         true,
 		},
 		{
 			desc:            "Testing zero lInfSensitivity",
@@ -675,8 +720,6 @@ func TestComputeConfidenceIntervalInt64Gaussian(t *testing.T) {
 			epsilon:         0.5,
 			delta:           0.9,
 			alpha:           0.2,
-			want:            ConfidenceInterval{},
-			wantErr:         true,
 		},
 		{
 			desc:            "Testing negative epsilon",
@@ -686,8 +729,6 @@ func TestComputeConfidenceIntervalInt64Gaussian(t *testing.T) {
 			epsilon:         -0.05, // epsilon should be strictly positive.
 			delta:           0.9,
 			alpha:           0.2,
-			want:            ConfidenceInterval{},
-			wantErr:         true,
 		},
 		{
 			desc:            "Testing infinite epsilon",
@@ -697,8 +738,6 @@ func TestComputeConfidenceIntervalInt64Gaussian(t *testing.T) {
 			epsilon:         math.Inf(1), // epsilon cannot be infinite.
 			delta:           0.9,
 			alpha:           0.2,
-			want:            ConfidenceInterval{},
-			wantErr:         true,
 		},
 		{
 			desc:            "Testing NaN epsilon",
@@ -708,8 +747,6 @@ func TestComputeConfidenceIntervalInt64Gaussian(t *testing.T) {
 			epsilon:         math.Inf(1), // epsilon cannot be NaN.
 			delta:           0.9,
 			alpha:           0.2,
-			want:            ConfidenceInterval{},
-			wantErr:         true,
 		},
 		{
 			desc:            "Testing negative delta",
@@ -719,8 +756,6 @@ func TestComputeConfidenceIntervalInt64Gaussian(t *testing.T) {
 			epsilon:         0.05,
 			delta:           -0.9, // delta should be strictly positive and smaller than 1.
 			alpha:           0.2,
-			want:            ConfidenceInterval{},
-			wantErr:         true,
 		},
 		{
 			desc:            "Testing bigger than 1 delta",
@@ -730,8 +765,6 @@ func TestComputeConfidenceIntervalInt64Gaussian(t *testing.T) {
 			epsilon:         0.05,
 			delta:           10, // delta should be strictly positive and smaller than 1.
 			alpha:           0.2,
-			want:            ConfidenceInterval{},
-			wantErr:         true,
 		},
 		{
 			desc:            "Testing zero delta",
@@ -741,8 +774,6 @@ func TestComputeConfidenceIntervalInt64Gaussian(t *testing.T) {
 			epsilon:         0.05,
 			delta:           10, // delta should be strictly positive and smaller than 1.
 			alpha:           0.2,
-			want:            ConfidenceInterval{},
-			wantErr:         true,
 		},
 		{
 			desc:          "Arbitrary test with 0 alpha",
@@ -751,8 +782,6 @@ func TestComputeConfidenceIntervalInt64Gaussian(t *testing.T) {
 			epsilon:       0.8,
 			delta:         0.8,
 			alpha:         0,
-			want:          ConfidenceInterval{},
-			wantErr:       true,
 		},
 		{
 			desc:            "Arbitrary test with 1 alpha",
@@ -762,8 +791,6 @@ func TestComputeConfidenceIntervalInt64Gaussian(t *testing.T) {
 			epsilon:         0.8,
 			delta:           0.8,
 			alpha:           1,
-			want:            ConfidenceInterval{},
-			wantErr:         true,
 		},
 		{
 			desc:            "Arbitrary test with negative alpha",
@@ -773,8 +800,6 @@ func TestComputeConfidenceIntervalInt64Gaussian(t *testing.T) {
 			epsilon:         0.8,
 			delta:           0.8,
 			alpha:           -1,
-			want:            ConfidenceInterval{},
-			wantErr:         true,
 		},
 		{
 			desc:            "Arbitrary test with greater than 1 alpha",
@@ -784,8 +809,6 @@ func TestComputeConfidenceIntervalInt64Gaussian(t *testing.T) {
 			epsilon:         0.8,
 			delta:           0.8,
 			alpha:           10,
-			want:            ConfidenceInterval{},
-			wantErr:         true,
 		},
 		{
 			desc:            "Arbitrary test with NaN alpha",
@@ -795,101 +818,47 @@ func TestComputeConfidenceIntervalInt64Gaussian(t *testing.T) {
 			epsilon:         0.8,
 			delta:           0.8,
 			alpha:           math.NaN(),
-			want:            ConfidenceInterval{},
-			wantErr:         true,
 		},
 	} {
 		got, err := gauss.ComputeConfidenceIntervalInt64(tc.noisedX, tc.l0Sensitivity, tc.lInfSensitivity, tc.epsilon, tc.delta, tc.alpha)
-		if (err != nil) != tc.wantErr {
-			t.Errorf("ComputeConfidenceIntervalInt64: when %s got err %v, wantErr=%t", tc.desc, err, tc.wantErr)
+		if err == nil {
+			t.Errorf("ComputeConfidenceIntervalInt64Gaussian: when %s no error was returned, expected error", tc.desc)
 		}
-		if got.LowerBound != tc.want.LowerBound {
-			t.Errorf("TestComputeConfidenceIntervalInt64(%d, %d, %d, %f, %f, %f)=%f, want %f, desc %s, LowerBound is not equal",
-				tc.noisedX, tc.l0Sensitivity, tc.lInfSensitivity, tc.epsilon, tc.delta, tc.alpha, got.LowerBound, tc.want.LowerBound, tc.desc)
-		}
-		if got.UpperBound != tc.want.UpperBound {
-			t.Errorf("TestComputeConfidenceIntervalInt64(%d, %d, %d, %f, %f, %f)=%f, want %f, desc %s, UpperBound is not equal",
-				tc.noisedX, tc.l0Sensitivity, tc.lInfSensitivity, tc.epsilon, tc.delta, tc.alpha, got.UpperBound, tc.want.UpperBound, tc.desc)
+		// Checks default confidence interval is returned when err is generated.
+		if (got != ConfidenceInterval{}) {
+			t.Errorf("TestComputeConfidenceIntervalInt64GaussianArgumentCheck(%d, %d, %d, %f, %f)=[LowerBound: %0.10f, UpperBound: %0.10f], want [LowerBound: 0.0, UpperBound: 0.0]",
+				tc.noisedX, tc.l0Sensitivity, tc.lInfSensitivity, tc.epsilon, tc.alpha, got.LowerBound, got.UpperBound)
 		}
 	}
 }
 
-func TestComputeConfidenceIntervalFloat64Gaussian(t *testing.T) {
+func TestComputeConfidenceIntervalFloat64GaussianArgumentCheck(t *testing.T) {
+	// Test
 	for _, tc := range []struct {
 		desc                                   string
 		noisedX                                float64
 		l0Sensitivity                          int64
 		lInfSensitivity, epsilon, delta, alpha float64
 		want                                   ConfidenceInterval
-		wantErr                                bool
 	}{
 		{
-			desc:            "Arbitrary test",
-			noisedX:         70.0,
-			l0Sensitivity:   5,
-			lInfSensitivity: 36,
-			epsilon:         0.8,
-			delta:           0.8,
-			alpha:           0.2,
-			want:            ConfidenceInterval{35.26815080641682, 104.73184919358317},
-			wantErr:         false,
-		},
-		{
-			desc:            "Arbitrary test with high alpha",
-			noisedX:         70.0,
-			l0Sensitivity:   5,
-			lInfSensitivity: 36,
-			epsilon:         0.8,
-			delta:           0.8,
-			alpha:           1 - 7.856382354e-10,
-			want:            ConfidenceInterval{69.9999999733, 70.0000000267},
-			wantErr:         false,
-		},
-		{
-			desc:            "Arbitrary test with low alpha",
-			noisedX:         70.0,
-			l0Sensitivity:   5,
-			lInfSensitivity: 36,
-			epsilon:         0.8,
-			delta:           0.8,
-			alpha:           7.856382354e-10,
-			want:            ConfidenceInterval{-96.6140883158, 236.6140883158},
-			wantErr:         false,
-		},
-		{
 			desc:            "Arbitrary test with 0 alpha",
-			noisedX:         598.21547558328,
+			noisedX:         598.21548,
 			l0Sensitivity:   5,
 			lInfSensitivity: 36,
 			epsilon:         0.8,
 			delta:           0.8,
 			alpha:           0,
-			want:            ConfidenceInterval{},
-			wantErr:         true,
 		},
 		{
 			desc:            "Arbitrary test with 1 alpha",
-			noisedX:         70,
+			noisedX:         70.0,
 			l0Sensitivity:   5,
 			lInfSensitivity: 36,
 			epsilon:         0.8,
 			delta:           0.8,
 			alpha:           1,
-			want:            ConfidenceInterval{},
-			wantErr:         true,
 		},
-		{
-			desc:            "Arbitrary test",
-			noisedX:         699.2402199905,
-			l0Sensitivity:   1,
-			lInfSensitivity: 5,
-			epsilon:         0.333,
-			delta:           0.9,
-			alpha:           0.001256458,
-			want:            ConfidenceInterval{694.5583238637953, 703.9221161172047},
-			wantErr:         false,
-		},
-		// Testing checkArgsConfidenceIntervalGaussian
 		{
 			desc:            "Testing alpha bigger than 1",
 			noisedX:         1,
@@ -898,8 +867,6 @@ func TestComputeConfidenceIntervalFloat64Gaussian(t *testing.T) {
 			epsilon:         0.5,
 			delta:           0.9,
 			alpha:           1.2, // alpha should not be smaller than 0.
-			want:            ConfidenceInterval{},
-			wantErr:         true,
 		},
 		{
 			desc:            "Testing negative alpha",
@@ -909,8 +876,6 @@ func TestComputeConfidenceIntervalFloat64Gaussian(t *testing.T) {
 			epsilon:         0.5,
 			delta:           0.9,
 			alpha:           -5, // alpha should not be smaller than 0.
-			want:            ConfidenceInterval{},
-			wantErr:         true,
 		},
 		{
 			desc:            "Testing negative l0Sensitivity",
@@ -920,8 +885,6 @@ func TestComputeConfidenceIntervalFloat64Gaussian(t *testing.T) {
 			epsilon:         0.5,
 			delta:           0.9,
 			alpha:           0.2,
-			want:            ConfidenceInterval{},
-			wantErr:         true,
 		},
 		{
 			desc:            "Testing zero l0Sensitivity",
@@ -931,8 +894,6 @@ func TestComputeConfidenceIntervalFloat64Gaussian(t *testing.T) {
 			epsilon:         0.5,
 			delta:           0.9,
 			alpha:           0.2,
-			want:            ConfidenceInterval{},
-			wantErr:         true,
 		},
 		{
 			desc:            "Testing negative lInfSensitivity",
@@ -942,8 +903,6 @@ func TestComputeConfidenceIntervalFloat64Gaussian(t *testing.T) {
 			epsilon:         0.5,
 			delta:           0.9,
 			alpha:           0.2,
-			want:            ConfidenceInterval{},
-			wantErr:         true,
 		},
 		{
 			desc:            "Testing zero lInfSensitivity",
@@ -953,8 +912,6 @@ func TestComputeConfidenceIntervalFloat64Gaussian(t *testing.T) {
 			epsilon:         0.5,
 			delta:           0.9,
 			alpha:           0.2,
-			want:            ConfidenceInterval{},
-			wantErr:         true,
 		},
 		{
 			desc:            "Testing positive infinity lInfSensitivity",
@@ -964,8 +921,6 @@ func TestComputeConfidenceIntervalFloat64Gaussian(t *testing.T) {
 			epsilon:         0.5,
 			delta:           0.9,
 			alpha:           0.2,
-			want:            ConfidenceInterval{},
-			wantErr:         true,
 		},
 		{
 			desc:            "Testing NaN lInfSensitivity",
@@ -975,8 +930,6 @@ func TestComputeConfidenceIntervalFloat64Gaussian(t *testing.T) {
 			epsilon:         0.5,
 			delta:           0.9,
 			alpha:           0.2,
-			want:            ConfidenceInterval{},
-			wantErr:         true,
 		},
 		{
 			desc:            "Testing negative epsilon",
@@ -986,8 +939,6 @@ func TestComputeConfidenceIntervalFloat64Gaussian(t *testing.T) {
 			epsilon:         -0.05, // epsilon should be strictly positive.
 			delta:           0.9,
 			alpha:           0.2,
-			want:            ConfidenceInterval{},
-			wantErr:         true,
 		},
 		{
 			desc:            "Testing infinite epsilon",
@@ -997,8 +948,6 @@ func TestComputeConfidenceIntervalFloat64Gaussian(t *testing.T) {
 			epsilon:         math.Inf(1), // epsilon should not be infinite.
 			delta:           0.9,
 			alpha:           0.2,
-			want:            ConfidenceInterval{},
-			wantErr:         true,
 		},
 		{
 			desc:            "Testing NaN epsilon",
@@ -1008,19 +957,15 @@ func TestComputeConfidenceIntervalFloat64Gaussian(t *testing.T) {
 			epsilon:         math.NaN(), // epsilon cannot be NaN.
 			delta:           0.9,
 			alpha:           0.2,
-			want:            ConfidenceInterval{},
-			wantErr:         true,
 		},
 		{
-			desc:            "Testing negative dela",
+			desc:            "Testing negative delta",
 			noisedX:         1,
 			l0Sensitivity:   4,
 			lInfSensitivity: 5,
 			epsilon:         0.05,
 			delta:           -0.9, // delta should be strictly positive and smaller than 1.
 			alpha:           0.2,
-			want:            ConfidenceInterval{},
-			wantErr:         true,
 		},
 		{
 			desc:            "Testing bigger than 1 delta",
@@ -1030,8 +975,6 @@ func TestComputeConfidenceIntervalFloat64Gaussian(t *testing.T) {
 			epsilon:         0.05,
 			delta:           10, // delta should be strictly positive and smaller than 1.
 			alpha:           0.2,
-			want:            ConfidenceInterval{},
-			wantErr:         true,
 		},
 		{
 			desc:            "Testing zero delta",
@@ -1041,8 +984,6 @@ func TestComputeConfidenceIntervalFloat64Gaussian(t *testing.T) {
 			epsilon:         0.05,
 			delta:           0, // delta should be strictly positive and smaller than 1.
 			alpha:           0.2,
-			want:            ConfidenceInterval{},
-			wantErr:         true,
 		},
 		{
 			desc:            "Testing infinite delta",
@@ -1052,21 +993,16 @@ func TestComputeConfidenceIntervalFloat64Gaussian(t *testing.T) {
 			epsilon:         0.05,
 			delta:           math.Inf(1), // delta should be strictly positive and smaller than 1.
 			alpha:           0.2,
-			want:            ConfidenceInterval{},
-			wantErr:         true,
 		},
 	} {
 		got, err := gauss.ComputeConfidenceIntervalFloat64(tc.noisedX, tc.l0Sensitivity, tc.lInfSensitivity, tc.epsilon, tc.delta, tc.alpha)
-		if (err != nil) != tc.wantErr {
-			t.Errorf("ComputeConfidenceIntervalFloat64: when %s got err %v, wantErr=%t", tc.desc, err, tc.wantErr)
+		if err == nil {
+			t.Errorf("ComputeConfidenceIntervalFloat64Gaussian: when %s no error was returned, expected error", tc.desc)
 		}
-		if !approxEqual(got.LowerBound, tc.want.LowerBound) {
-			t.Errorf("TestComputeConfidenceIntervalFloat64(%f, %d, %f, %f, %f)=%0.10f, want %0.10f, desc %s, LowerBound is not equal",
-				tc.noisedX, tc.l0Sensitivity, tc.lInfSensitivity, tc.epsilon, tc.alpha, got.UpperBound, tc.want.UpperBound, tc.desc)
-		}
-		if !approxEqual(got.UpperBound, tc.want.UpperBound) {
-			t.Errorf("TestComputeConfidenceIntervalFloat64(%f, %d, %f, %f, %f)=%0.10f, want %0.10f, desc %s, UpperBound is not equal",
-				tc.noisedX, tc.l0Sensitivity, tc.lInfSensitivity, tc.epsilon, tc.alpha, got.LowerBound, tc.want.LowerBound, tc.desc)
+		// Checks default confidence interval is returned when err is generated.
+		if (got != ConfidenceInterval{}) {
+			t.Errorf("TestComputeConfidenceIntervalFloat64GaussianArgumentCheck(%f, %d, %f, %f, %f)=[LowerBound: %0.10f, UpperBound: %0.10f], want [LowerBound: 0.0, UpperBound: 0.0]",
+				tc.noisedX, tc.l0Sensitivity, tc.lInfSensitivity, tc.epsilon, tc.alpha, got.LowerBound, got.UpperBound)
 		}
 	}
 }

--- a/go/noise/laplace_noise_test.go
+++ b/go/noise/laplace_noise_test.go
@@ -219,7 +219,7 @@ func TestInverseCDFLaplace(t *testing.T) {
 	} {
 		got := inverseCDFLaplace(tc.lambda, tc.prob)
 		if !approxEqual(got, tc.want) {
-			t.Errorf("TestInverseCDFLaplace(%f,%f)=%0.12f, want %0.12f, desc: %s", tc.lambda,
+			t.Errorf("inverseCDFLaplace(%f,%f)=%0.12f, want %0.12f, desc: %s", tc.lambda,
 				tc.prob, got, tc.want, tc.desc)
 		}
 	}
@@ -292,11 +292,11 @@ func TestComputeConfidenceIntervalLaplace(t *testing.T) {
 	} {
 		got := computeConfidenceIntervalLaplace(tc.noisedX, tc.lambda, tc.alpha)
 		if !approxEqual(got.LowerBound, tc.want.LowerBound) {
-			t.Errorf("TestComputeConfidenceIntervalLaplace(%f, %f, %f)=%0.10f, want %0.10f, desc %s, LowerBounds are not equal",
+			t.Errorf("computeConfidenceIntervalLaplace(%f, %f, %f)=%0.10f, want %0.10f, desc %s, LowerBounds are not equal",
 				tc.noisedX, tc.lambda, tc.alpha, got.LowerBound, tc.want.LowerBound, tc.desc)
 		}
 		if !approxEqual(got.UpperBound, tc.want.UpperBound) {
-			t.Errorf("TestComputeConfidenceIntervalLaplace(%f, %f, %f)=%0.10f, want %0.10f, desc %s, UpperBounds are not equal",
+			t.Errorf("computeConfidenceIntervalLaplace(%f, %f, %f)=%0.10f, want %0.10f, desc %s, UpperBounds are not equal",
 				tc.noisedX, tc.lambda, tc.alpha, got.UpperBound, tc.want.UpperBound, tc.desc)
 		}
 	}
@@ -439,16 +439,11 @@ func TestComputeConfidenceIntervalFloat64LaplaceArgumentCheck(t *testing.T) {
 			alpha:           math.NaN(),
 		},
 	} {
-		got, err := lap.ComputeConfidenceIntervalFloat64(tc.noisedX, tc.l0Sensitivity, tc.lInfSensitivity,
+		_, err := lap.ComputeConfidenceIntervalFloat64(tc.noisedX, tc.l0Sensitivity, tc.lInfSensitivity,
 			tc.epsilon, tc.delta, tc.alpha)
 
 		if err == nil {
-			t.Errorf("ComputeConfidenceIntervalFloat64Laplace: when %s no error was returned, expected error", tc.desc)
-		}
-		// Checks default confidence interval is returned when err is generated.
-		if (got != ConfidenceInterval{}) {
-			t.Errorf("TestComputeConfidenceIntervalFloat64LaplaceArgumentCheck(%f, %d, %f, %f, %f)=[LowerBound: %0.10f, UpperBound: %0.10f], want [LowerBound: 0.0, UpperBound: 0.0]",
-				tc.noisedX, tc.l0Sensitivity, tc.lInfSensitivity, tc.epsilon, tc.alpha, got.LowerBound, got.UpperBound)
+			t.Errorf("ComputeConfidenceIntervalFloat64: when %s no error was returned, expected error", tc.desc)
 		}
 	}
 }
@@ -494,14 +489,14 @@ func TestComputeConfidenceIntervalInt64Laplace(t *testing.T) {
 		got, err := lap.ComputeConfidenceIntervalInt64(tc.noisedX, tc.l0Sensitivity, tc.lInfSensitivity,
 			tc.epsilon, tc.delta, tc.alpha)
 		if err != nil {
-			t.Errorf("ComputeConfidenceIntervalInt64Laplace: when %v for err got %v", tc.desc, err)
+			t.Errorf("ComputeConfidenceIntervalInt64: when %v for err got %v", tc.desc, err)
 		}
 		if got.LowerBound != tc.want.LowerBound {
-			t.Errorf("TestComputeConfidenceIntervalInt64Laplace(%d, %d, %d, %f, %f)=%0.10f, want %0.10f, desc %s, LowerBounds are not equal",
+			t.Errorf("ComputeConfidenceIntervalInt64(%d, %d, %d, %f, %f)=%0.10f, want %0.10f, desc %s, LowerBounds are not equal",
 				tc.noisedX, tc.l0Sensitivity, tc.lInfSensitivity, tc.epsilon, tc.alpha, got.LowerBound, tc.want.LowerBound, tc.desc)
 		}
 		if got.UpperBound != tc.want.UpperBound {
-			t.Errorf("TestComputeConfidenceIntervalInt64Laplace(%d, %d, %d, %f, %f)=%0.10f, want %0.10f, desc %s, UpperBounds are not equal",
+			t.Errorf("ComputeConfidenceIntervalInt64(%d, %d, %d, %f, %f)=%0.10f, want %0.10f, desc %s, UpperBounds are not equal",
 				tc.noisedX, tc.l0Sensitivity, tc.lInfSensitivity, tc.epsilon, tc.alpha, got.UpperBound, tc.want.UpperBound, tc.desc)
 		}
 	}
@@ -627,16 +622,11 @@ func TestComputeConfidenceIntervalInt64LaplaceArgumentCheck(t *testing.T) {
 			alpha:           math.NaN(),
 		},
 	} {
-		got, err := lap.ComputeConfidenceIntervalInt64(tc.noisedX, tc.l0Sensitivity, tc.lInfSensitivity,
+		_, err := lap.ComputeConfidenceIntervalInt64(tc.noisedX, tc.l0Sensitivity, tc.lInfSensitivity,
 			tc.epsilon, tc.delta, tc.alpha)
 
 		if err == nil {
-			t.Errorf("ComputeConfidenceIntervalInt64Laplace: when %s no error was returned, expected error", tc.desc)
-		}
-		// Checks default confidence interval is returned when err is generated.
-		if (got != ConfidenceInterval{}) {
-			t.Errorf("TestComputeConfidenceIntervalInt64LaplaceArgumentCheck(%d, %d, %d, %f, %f)=[LowerBound: %0.10f, UpperBound: %0.10f], want [LowerBound: 0.0, UpperBound: 0.0]",
-				tc.noisedX, tc.l0Sensitivity, tc.lInfSensitivity, tc.epsilon, tc.alpha, got.LowerBound, got.UpperBound)
+			t.Errorf("ComputeConfidenceIntervalInt64: when %s no error was returned, expected error", tc.desc)
 		}
 	}
 }

--- a/go/noise/laplace_noise_test.go
+++ b/go/noise/laplace_noise_test.go
@@ -126,7 +126,7 @@ func TestThresholdLaplace(t *testing.T) {
 		{1, 10, ln3, 1 - 1e-10, -193.28},
 		// Scale l0Sensitivity
 		{10, 10, 10 * ln3, 1e-9, 213.28},
-		{10, 10, 10 * ln3, 1 - 1e-9, -2.55}, // l0Sensitivity != 1, not expecting symmetry in "want" threhsold around lInfSensitivity.
+		{10, 10, 10 * ln3, 1 - 1e-9, -2.55}, // l0Sensitivity != 1, not expecting symmetry in "want" threshold around lInfSensitivity.
 		// High precision delta case
 		{1, 1, ln3, 1e-200, 419.55},
 	} {
@@ -180,41 +180,41 @@ func TestInverseCDFLaplace(t *testing.T) {
 	}{
 		{
 			desc:   "Arbitrary test",
-			lambda: 4,
-			prob:   0.7875404240919761168041,
-			want:   3.4234254367,
+			lambda: 4.0,
+			prob:   0.78754042,
+			want:   3.4234254,
 		},
 		{
 			desc:   "Arbitrary test",
-			lambda: 2,
-			prob:   0.1479685611330654517049,
-			want:   -2.435216544,
+			lambda: 2.0,
+			prob:   0.14796856,
+			want:   -2.4352165,
 		},
 		// For a probability of 0.5, the result should be the zero regardless of lambda.
 		{
 			desc:   "0.5 Probability, output is zero",
-			lambda: 5,
+			lambda: 5.0,
 			prob:   0.5,
 			want:   0,
 		},
 		{
 			desc:   "0.5 Probability, output is zero",
-			lambda: 10,
+			lambda: 10.0,
 			prob:   0.5,
 			want:   0,
 		},
 		// Tests for convergence to infinities with low and high probabilities.
 		{
 			desc:   "Low probability",
-			lambda: 3,
-			prob:   1.23757362e-15,
-			want:   -100.897429529251364,
+			lambda: 3.0,
+			prob:   1.2375736e-15,
+			want:   -100.89743,
 		},
 		{
 			desc:   "High probability",
-			lambda: 3,
-			prob:   0.999999999876242638,
-			want:   66.3586531343406788,
+			lambda: 3.0,
+			prob:   1 - 1.237574E-10,
+			want:   66.358653,
 		},
 	} {
 		got := inverseCDFLaplace(tc.lambda, tc.prob)
@@ -234,45 +234,60 @@ func TestComputeConfidenceIntervalLaplace(t *testing.T) {
 	}{
 		{
 			desc:    "Arbitrary test",
-			noisedX: 13,
-			lambda:  27.33333333333,
+			noisedX: 13.0,
+			lambda:  27.333333,
 			alpha:   0.05,
-			want:    ConfidenceInterval{-68.88334881, 94.88334881},
+			want:    ConfidenceInterval{-68.883349, 94.883349},
 		},
 		{
 			desc:    "Arbitrary test",
 			noisedX: 83.1235,
-			lambda:  60,
+			lambda:  60.0,
 			alpha:   0.24,
-			want:    ConfidenceInterval{-2.503481338, 168.7504813},
+			want:    ConfidenceInterval{-2.5034813, 168.75048},
 		},
 		{
 			desc:    "Arbitrary test",
-			noisedX: 5,
-			lambda:  6.6666666666667,
+			noisedX: 5.0,
+			lambda:  6.6666667,
 			alpha:   0.6,
-			want:    ConfidenceInterval{1.594495842, 8.405504158},
+			want:    ConfidenceInterval{1.5944958, 8.40550416},
 		},
 		{
 			desc:    "Arbitrary test",
 			noisedX: 65.4621,
-			lambda:  700,
+			lambda:  700.0,
 			alpha:   0.8,
-			want:    ConfidenceInterval{-90.73838592, 221.6625859},
+			want:    ConfidenceInterval{-90.738386, 221.66259},
 		},
 		{
 			desc:    "Extremely low confidence level",
 			noisedX: 0,
-			lambda:  10,
-			alpha:   1 - 3.548957438e-10,
-			want:    ConfidenceInterval{-3.548957437370245055312e-9, 3.548957437370245055312e-9},
+			lambda:  10.0,
+			alpha:   1 - 3.5489574e-10,
+			want:    ConfidenceInterval{-3.5489574e-9, 3.5489574e-9},
 		},
 		{
 			desc:    "Extremely high confidence level",
-			noisedX: 50,
-			lambda:  10,
-			alpha:   7.856382354e-10,
-			want:    ConfidenceInterval{-159.6452468975697118041, 259.6452468975697118041},
+			noisedX: 50.0,
+			lambda:  10.0,
+			alpha:   7.8563824e-10,
+			want:    ConfidenceInterval{-159.64525, 259.64525},
+		},
+		// Testing that bounds are accurate for abs(bound) < 2^53
+		{
+			desc:    "Large positive noisedX",
+			noisedX: 38475693.0,
+			lambda:  10.0,
+			alpha:   0.1,
+			want:    ConfidenceInterval{38475670.0, 38475716.0},
+		},
+		{
+			desc:    "Large negative noisedX",
+			noisedX: -38475693.0,
+			lambda:  10.0,
+			alpha:   0.1,
+			want:    ConfidenceInterval{-38475716.0, -38475670.0},
 		},
 	} {
 		got := computeConfidenceIntervalLaplace(tc.noisedX, tc.lambda, tc.alpha)
@@ -287,25 +302,13 @@ func TestComputeConfidenceIntervalLaplace(t *testing.T) {
 	}
 }
 
-func TestComputeConfidenceIntervalFloat64Laplace(t *testing.T) {
+func TestComputeConfidenceIntervalFloat64LaplaceArgumentCheck(t *testing.T) {
 	for _, tc := range []struct {
 		desc                                   string
 		noisedX                                float64
 		l0Sensitivity                          int64
 		lInfSensitivity, epsilon, alpha, delta float64
-		want                                   ConfidenceInterval
-		wantErr                                bool
 	}{
-		{
-			desc:            "Arbitrary test",
-			noisedX:         38.4234,
-			l0Sensitivity:   2,
-			lInfSensitivity: 4.3,
-			epsilon:         0.6,
-			alpha:           0.2,
-			want:            ConfidenceInterval{15.35478992, 61.49201008},
-		},
-		// Argument checking
 		{
 			desc:            "Zero l0Sensitivity",
 			noisedX:         0,
@@ -313,8 +316,6 @@ func TestComputeConfidenceIntervalFloat64Laplace(t *testing.T) {
 			lInfSensitivity: 1,
 			epsilon:         0.1,
 			alpha:           0.5,
-			want:            ConfidenceInterval{},
-			wantErr:         true,
 		},
 		{
 			desc:            "Negative l0Sensitivity",
@@ -323,8 +324,6 @@ func TestComputeConfidenceIntervalFloat64Laplace(t *testing.T) {
 			lInfSensitivity: 1,
 			epsilon:         0.1,
 			alpha:           0.5,
-			want:            ConfidenceInterval{},
-			wantErr:         true,
 		},
 		{
 			desc:            "Zero lInfSensitivity",
@@ -333,8 +332,6 @@ func TestComputeConfidenceIntervalFloat64Laplace(t *testing.T) {
 			lInfSensitivity: 0,
 			epsilon:         0.1,
 			alpha:           0.5,
-			want:            ConfidenceInterval{},
-			wantErr:         true,
 		},
 		{
 			desc:            "Negative lInfSensitivity",
@@ -343,8 +340,6 @@ func TestComputeConfidenceIntervalFloat64Laplace(t *testing.T) {
 			lInfSensitivity: -1,
 			epsilon:         0.1,
 			alpha:           0.5,
-			want:            ConfidenceInterval{},
-			wantErr:         true,
 		},
 		{
 			desc:            "Infinite lInfSensitivity",
@@ -353,8 +348,6 @@ func TestComputeConfidenceIntervalFloat64Laplace(t *testing.T) {
 			lInfSensitivity: math.Inf(1),
 			epsilon:         0.1,
 			alpha:           0.5,
-			want:            ConfidenceInterval{},
-			wantErr:         true,
 		},
 		{
 			desc:            "NaN lInfSensitivity",
@@ -363,18 +356,14 @@ func TestComputeConfidenceIntervalFloat64Laplace(t *testing.T) {
 			lInfSensitivity: math.NaN(),
 			epsilon:         0.1,
 			alpha:           0.5,
-			want:            ConfidenceInterval{},
-			wantErr:         true,
 		},
 		{
-			desc:            "Zero epsilon",
+			desc:            "Epsilon less than 2^-50",
 			noisedX:         0,
 			l0Sensitivity:   1,
 			lInfSensitivity: 1,
-			epsilon:         0,
+			epsilon:         1.0 / (1 << 51),
 			alpha:           0.5,
-			want:            ConfidenceInterval{},
-			wantErr:         true,
 		},
 		{
 			desc:            "Negative epsilon",
@@ -383,8 +372,6 @@ func TestComputeConfidenceIntervalFloat64Laplace(t *testing.T) {
 			lInfSensitivity: 1,
 			epsilon:         -1,
 			alpha:           0.5,
-			want:            ConfidenceInterval{},
-			wantErr:         true,
 		},
 		{
 			desc:            "Infinite epsilon",
@@ -393,8 +380,6 @@ func TestComputeConfidenceIntervalFloat64Laplace(t *testing.T) {
 			lInfSensitivity: 1,
 			epsilon:         math.Inf(1),
 			alpha:           0.5,
-			want:            ConfidenceInterval{},
-			wantErr:         true,
 		},
 		{
 			desc:            "NaN epsilon",
@@ -403,8 +388,6 @@ func TestComputeConfidenceIntervalFloat64Laplace(t *testing.T) {
 			lInfSensitivity: 1,
 			epsilon:         math.NaN(),
 			alpha:           0.5,
-			want:            ConfidenceInterval{},
-			wantErr:         true,
 		},
 		{
 			desc:            "Non-zero delta",
@@ -414,8 +397,6 @@ func TestComputeConfidenceIntervalFloat64Laplace(t *testing.T) {
 			epsilon:         0.1,
 			delta:           1,
 			alpha:           0.5,
-			want:            ConfidenceInterval{},
-			wantErr:         true,
 		},
 		{
 			desc:            "Zero alpha",
@@ -424,8 +405,6 @@ func TestComputeConfidenceIntervalFloat64Laplace(t *testing.T) {
 			lInfSensitivity: 1,
 			epsilon:         0.1,
 			alpha:           0,
-			want:            ConfidenceInterval{},
-			wantErr:         true,
 		},
 		{
 			desc:            "Negative alpha",
@@ -434,8 +413,6 @@ func TestComputeConfidenceIntervalFloat64Laplace(t *testing.T) {
 			lInfSensitivity: 1,
 			epsilon:         0.1,
 			alpha:           -1,
-			want:            ConfidenceInterval{},
-			wantErr:         true,
 		},
 		{
 			desc:            "1 alpha",
@@ -444,8 +421,6 @@ func TestComputeConfidenceIntervalFloat64Laplace(t *testing.T) {
 			lInfSensitivity: 1,
 			epsilon:         0.1,
 			alpha:           1,
-			want:            ConfidenceInterval{},
-			wantErr:         true,
 		},
 		{
 			desc:            "Greater than 1 alpha",
@@ -454,8 +429,6 @@ func TestComputeConfidenceIntervalFloat64Laplace(t *testing.T) {
 			lInfSensitivity: 1,
 			epsilon:         0.1,
 			alpha:           2,
-			want:            ConfidenceInterval{},
-			wantErr:         true,
 		},
 		{
 			desc:            "NaN alpha",
@@ -464,22 +437,18 @@ func TestComputeConfidenceIntervalFloat64Laplace(t *testing.T) {
 			lInfSensitivity: 1,
 			epsilon:         0.1,
 			alpha:           math.NaN(),
-			want:            ConfidenceInterval{},
-			wantErr:         true,
 		},
 	} {
 		got, err := lap.ComputeConfidenceIntervalFloat64(tc.noisedX, tc.l0Sensitivity, tc.lInfSensitivity,
 			tc.epsilon, tc.delta, tc.alpha)
-		if (err != nil) != tc.wantErr {
-			t.Errorf("ComputeConfidenceIntervalFloat64Laplace: when %v for err got %v, want %t", tc.desc, err, tc.wantErr)
+
+		if err == nil {
+			t.Errorf("ComputeConfidenceIntervalFloat64Laplace: when %s no error was returned, expected error", tc.desc)
 		}
-		if !approxEqual(got.LowerBound, tc.want.LowerBound) {
-			t.Errorf("TestComputeConfidenceIntervalFloat64Laplace(%f, %d, %f, %f, %f)=%0.10f, want %0.10f, desc %s, LowerBounds are not equal",
-				tc.noisedX, tc.l0Sensitivity, tc.lInfSensitivity, tc.epsilon, tc.alpha, got.LowerBound, tc.want.LowerBound, tc.desc)
-		}
-		if !approxEqual(got.UpperBound, tc.want.UpperBound) {
-			t.Errorf("TestComputeConfidenceIntervalFloat64Laplace(%f, %d, %f, %f, %f)=%0.10f, want %0.10f, desc %s, UpperBounds are not equal",
-				tc.noisedX, tc.l0Sensitivity, tc.lInfSensitivity, tc.epsilon, tc.alpha, got.UpperBound, tc.want.UpperBound, tc.desc)
+		// Checks default confidence interval is returned when err is generated.
+		if (got != ConfidenceInterval{}) {
+			t.Errorf("TestComputeConfidenceIntervalFloat64LaplaceArgumentCheck(%f, %d, %f, %f, %f)=[LowerBound: %0.10f, UpperBound: %0.10f], want [LowerBound: 0.0, UpperBound: 0.0]",
+				tc.noisedX, tc.l0Sensitivity, tc.lInfSensitivity, tc.epsilon, tc.alpha, got.LowerBound, got.UpperBound)
 		}
 	}
 }
@@ -490,7 +459,6 @@ func TestComputeConfidenceIntervalInt64Laplace(t *testing.T) {
 		noisedX, l0Sensitivity, lInfSensitivity int64
 		epsilon, delta, alpha                   float64
 		want                                    ConfidenceInterval
-		wantErr                                 bool
 	}{
 		{
 			desc:            "Arbitrary test",
@@ -501,7 +469,50 @@ func TestComputeConfidenceIntervalInt64Laplace(t *testing.T) {
 			alpha:           0.8,
 			want:            ConfidenceInterval{-79, 55},
 		},
-		// Argument checking
+		// Tests for nextSmallerFloat64 and nextLargerFloat64.
+		{
+			desc: "Large positive noisedX",
+			// Distance to neighbouring float64 values is greater than half the size of the confidence interval.
+			noisedX:         (1 << 58),
+			l0Sensitivity:   1,
+			lInfSensitivity: 1,
+			epsilon:         0.1,
+			alpha:           0.1,
+			want:            ConfidenceInterval{math.Nextafter(1<<58, math.Inf(-1)), math.Nextafter(1<<58, math.Inf(1))},
+		},
+		{
+			desc: "Large negative noisedX",
+			// Distance to neighbouring float64 values is greater than half the size of the confidence interval.
+			noisedX:         -(1 << 58),
+			l0Sensitivity:   1,
+			lInfSensitivity: 1,
+			epsilon:         0.1,
+			alpha:           0.1,
+			want:            ConfidenceInterval{math.Nextafter(-1<<58, math.Inf(-1)), math.Nextafter(-1<<58, math.Inf(1))},
+		},
+	} {
+		got, err := lap.ComputeConfidenceIntervalInt64(tc.noisedX, tc.l0Sensitivity, tc.lInfSensitivity,
+			tc.epsilon, tc.delta, tc.alpha)
+		if err != nil {
+			t.Errorf("ComputeConfidenceIntervalInt64Laplace: when %v for err got %v", tc.desc, err)
+		}
+		if got.LowerBound != tc.want.LowerBound {
+			t.Errorf("TestComputeConfidenceIntervalInt64Laplace(%d, %d, %d, %f, %f)=%0.10f, want %0.10f, desc %s, LowerBounds are not equal",
+				tc.noisedX, tc.l0Sensitivity, tc.lInfSensitivity, tc.epsilon, tc.alpha, got.LowerBound, tc.want.LowerBound, tc.desc)
+		}
+		if got.UpperBound != tc.want.UpperBound {
+			t.Errorf("TestComputeConfidenceIntervalInt64Laplace(%d, %d, %d, %f, %f)=%0.10f, want %0.10f, desc %s, UpperBounds are not equal",
+				tc.noisedX, tc.l0Sensitivity, tc.lInfSensitivity, tc.epsilon, tc.alpha, got.UpperBound, tc.want.UpperBound, tc.desc)
+		}
+	}
+}
+
+func TestComputeConfidenceIntervalInt64LaplaceArgumentCheck(t *testing.T) {
+	for _, tc := range []struct {
+		desc                                    string
+		noisedX, l0Sensitivity, lInfSensitivity int64
+		epsilon, alpha, delta                   float64
+	}{
 		{
 			desc:            "Zero l0Sensitivity",
 			noisedX:         0,
@@ -509,8 +520,6 @@ func TestComputeConfidenceIntervalInt64Laplace(t *testing.T) {
 			lInfSensitivity: 1,
 			epsilon:         0.1,
 			alpha:           0.5,
-			want:            ConfidenceInterval{},
-			wantErr:         true,
 		},
 		{
 			desc:            "Negative l0Sensitivity",
@@ -519,8 +528,6 @@ func TestComputeConfidenceIntervalInt64Laplace(t *testing.T) {
 			lInfSensitivity: 1,
 			epsilon:         0.1,
 			alpha:           0.5,
-			want:            ConfidenceInterval{},
-			wantErr:         true,
 		},
 		{
 			desc:            "Zero lInfSensitivity",
@@ -529,8 +536,6 @@ func TestComputeConfidenceIntervalInt64Laplace(t *testing.T) {
 			lInfSensitivity: 0,
 			epsilon:         0.1,
 			alpha:           0.5,
-			want:            ConfidenceInterval{},
-			wantErr:         true,
 		},
 		{
 			desc:            "Negative lInfSensitivity",
@@ -539,18 +544,14 @@ func TestComputeConfidenceIntervalInt64Laplace(t *testing.T) {
 			lInfSensitivity: -1,
 			epsilon:         0.1,
 			alpha:           0.5,
-			want:            ConfidenceInterval{},
-			wantErr:         true,
 		},
 		{
-			desc:            "Zero epsilon",
+			desc:            "Epsilon less than 2^-50",
 			noisedX:         0,
 			l0Sensitivity:   1,
 			lInfSensitivity: 1,
-			epsilon:         0,
+			epsilon:         1.0 / (1 << 51),
 			alpha:           0.5,
-			want:            ConfidenceInterval{},
-			wantErr:         true,
 		},
 		{
 			desc:            "Negative epsilon",
@@ -559,8 +560,6 @@ func TestComputeConfidenceIntervalInt64Laplace(t *testing.T) {
 			lInfSensitivity: 1,
 			epsilon:         -1,
 			alpha:           0.5,
-			want:            ConfidenceInterval{},
-			wantErr:         true,
 		},
 		{
 			desc:            "Infinite epsilon",
@@ -569,8 +568,6 @@ func TestComputeConfidenceIntervalInt64Laplace(t *testing.T) {
 			lInfSensitivity: 1,
 			epsilon:         math.Inf(1),
 			alpha:           0.5,
-			want:            ConfidenceInterval{},
-			wantErr:         true,
 		},
 		{
 			desc:            "NaN epsilon",
@@ -579,8 +576,6 @@ func TestComputeConfidenceIntervalInt64Laplace(t *testing.T) {
 			lInfSensitivity: 1,
 			epsilon:         math.NaN(),
 			alpha:           0.5,
-			want:            ConfidenceInterval{},
-			wantErr:         true,
 		},
 		{
 			desc:            "Non-zero delta",
@@ -590,8 +585,6 @@ func TestComputeConfidenceIntervalInt64Laplace(t *testing.T) {
 			epsilon:         0.1,
 			delta:           1,
 			alpha:           0.5,
-			want:            ConfidenceInterval{},
-			wantErr:         true,
 		},
 		{
 			desc:            "Zero alpha",
@@ -600,8 +593,6 @@ func TestComputeConfidenceIntervalInt64Laplace(t *testing.T) {
 			lInfSensitivity: 1,
 			epsilon:         0.1,
 			alpha:           0,
-			want:            ConfidenceInterval{},
-			wantErr:         true,
 		},
 		{
 			desc:            "Negative alpha",
@@ -610,8 +601,6 @@ func TestComputeConfidenceIntervalInt64Laplace(t *testing.T) {
 			lInfSensitivity: 1,
 			epsilon:         0.1,
 			alpha:           -1,
-			want:            ConfidenceInterval{},
-			wantErr:         true,
 		},
 		{
 			desc:            "1 alpha",
@@ -620,8 +609,6 @@ func TestComputeConfidenceIntervalInt64Laplace(t *testing.T) {
 			lInfSensitivity: 1,
 			epsilon:         0.1,
 			alpha:           1,
-			want:            ConfidenceInterval{},
-			wantErr:         true,
 		},
 		{
 			desc:            "Greater than 1 alpha",
@@ -630,8 +617,6 @@ func TestComputeConfidenceIntervalInt64Laplace(t *testing.T) {
 			lInfSensitivity: 1,
 			epsilon:         0.1,
 			alpha:           2,
-			want:            ConfidenceInterval{},
-			wantErr:         true,
 		},
 		{
 			desc:            "NaN alpha",
@@ -640,22 +625,18 @@ func TestComputeConfidenceIntervalInt64Laplace(t *testing.T) {
 			lInfSensitivity: 1,
 			epsilon:         0.1,
 			alpha:           math.NaN(),
-			want:            ConfidenceInterval{},
-			wantErr:         true,
 		},
 	} {
 		got, err := lap.ComputeConfidenceIntervalInt64(tc.noisedX, tc.l0Sensitivity, tc.lInfSensitivity,
 			tc.epsilon, tc.delta, tc.alpha)
-		if (err != nil) != tc.wantErr {
-			t.Errorf("ComputeConfidenceIntervalInt64Laplace: when %v for err got %v, want %t", tc.desc, err, tc.wantErr)
+
+		if err == nil {
+			t.Errorf("ComputeConfidenceIntervalInt64Laplace: when %s no error was returned, expected error", tc.desc)
 		}
-		if got.LowerBound != tc.want.LowerBound {
-			t.Errorf("TestComputeConfidenceIntervalInt64Laplace(%d, %d, %d, %f, %f)=%0.10f, want %0.10f, desc %s, LowerBounds are not equal",
-				tc.noisedX, tc.l0Sensitivity, tc.lInfSensitivity, tc.epsilon, tc.alpha, got.LowerBound, tc.want.LowerBound, tc.desc)
-		}
-		if got.UpperBound != tc.want.UpperBound {
-			t.Errorf("TestComputeConfidenceIntervalInt64Laplace(%d, %d, %d, %f, %f)=%0.10f, want %0.10f, desc %s, UpperBounds are not equal",
-				tc.noisedX, tc.l0Sensitivity, tc.lInfSensitivity, tc.epsilon, tc.alpha, got.UpperBound, tc.want.UpperBound, tc.desc)
+		// Checks default confidence interval is returned when err is generated.
+		if (got != ConfidenceInterval{}) {
+			t.Errorf("TestComputeConfidenceIntervalInt64LaplaceArgumentCheck(%d, %d, %d, %f, %f)=[LowerBound: %0.10f, UpperBound: %0.10f], want [LowerBound: 0.0, UpperBound: 0.0]",
+				tc.noisedX, tc.l0Sensitivity, tc.lInfSensitivity, tc.epsilon, tc.alpha, got.LowerBound, got.UpperBound)
 		}
 	}
 }

--- a/go/noise/secure_noise_math.go
+++ b/go/noise/secure_noise_math.go
@@ -78,8 +78,8 @@ func nextLargerFloat64(n int64) float64 {
 	// the difference a - n will be negative, indicating that the result needs to be incremented
 	// to the next float64 value b.
 	result := float64(n)
-	dif := int64(result) - n
-	if dif < 0 {
+	diff := int64(result) - n
+	if diff < 0 {
 		return math.Nextafter(result, math.Inf(1))
 	}
 	return result
@@ -93,8 +93,8 @@ func nextSmallerFloat64(n int64) float64 {
 	// the difference b - n will be positive, indicating that the result needs to be decremented
 	// to the previous float64 value a.
 	result := float64(n)
-	dif := int64(result) - n
-	if dif > 0 {
+	diff := int64(result) - n
+	if diff > 0 {
 		return math.Nextafter(result, math.Inf(-1))
 	}
 	return result

--- a/go/noise/secure_noise_math.go
+++ b/go/noise/secure_noise_math.go
@@ -64,3 +64,38 @@ func ceilPowerOfTwo(x float64) float64 {
 func roundToMultipleOfPowerOfTwo(x, granularity float64) float64 {
 	return math.Round(x/granularity) * granularity
 }
+
+// nextLargerFloat64 computes the closest float64 value that is larger than or equal to the provided int64 value.
+//
+// Mapping from int64 to float64 for large int64 values (> 2^53) is inaccurate since they cannot be
+// represented as a float64. Implicit/explicit conversion from int64 to float64 either rounds up or
+// down the int64 value to the nearest representable float64. This function ensures that int64 n <=
+// float64 nextLargerFloat64(n)
+func nextLargerFloat64(n int64) float64 {
+	// Large int64 values n may lie between two representable float64 values a and b,
+	// i.e., a < n < b, (note that in this case a and b are guaranteed to be integers).
+	// If the standard conversion to float64 rounds the int64 value down, e.g. float64(n) = a,
+	// the difference a - n will be negative, indicating that the result needs to be incremented
+	// to the next float64 value b.
+	result := float64(n)
+	dif := int64(result) - n
+	if dif < 0 {
+		return math.Nextafter(result, math.Inf(1))
+	}
+	return result
+}
+
+// nextSmallerFloat64 computes the closest float64 value that is smaller than or equal to the provided int64 value.
+func nextSmallerFloat64(n int64) float64 {
+	// Large int64 values n may lie between two representable float64 values a and b,
+	// i.e., a < n < b, (note that in this case a and b are guaranteed to be integers).
+	// If the standard conversion to float64 rounds the int64 value up, e.g. int64(n) = b,
+	// the difference b - n will be positive, indicating that the result needs to be decremented
+	// to the previous float64 value a.
+	result := float64(n)
+	dif := int64(result) - n
+	if dif > 0 {
+		return math.Nextafter(result, math.Inf(-1))
+	}
+	return result
+}

--- a/go/noise/secure_noise_math_test.go
+++ b/go/noise/secure_noise_math_test.go
@@ -257,3 +257,109 @@ func TestRoundToMultipleOfPowerOfTwoXIsNotAMultiple(t *testing.T) {
 		}
 	}
 }
+
+func TestNextLargerFloat64InputRepresentableAsFloat64(t *testing.T) {
+	// Verify that nextLargerFloat64 returns a float64 of the same value.
+	for _, x := range []int64{
+		0,
+		1,
+		-1,
+		// Smallest positive float64 for which next float64 is a distance of 2 away.
+		9007199254740992,
+		// Largest negative float64 for which previous float64 is a distance of 2 away.
+		-9007199254740992,
+		// Arbitrary representable number.
+		8646911284551352320,
+		-8646911284551352320,
+		// Largest int64 value accurately representable as a float64.
+		math.MaxInt64 - 1023,
+		// Smallest int64 value accurately representable as a float64.
+		math.MinInt64,
+	} {
+		got := int64(nextLargerFloat64(x))
+		if got != x {
+			t.Errorf("nextLargerFloat64(%d) = %d, want %d", x, got, x)
+		}
+	}
+}
+
+func TestNextLargerFloat64InputNotRepresentableAsFloat64(t *testing.T) {
+	// Verify that nextLargerFloat64 computes the closest float64 value that is larger than
+	// or equal to the provided int64 value.
+	for _, tc := range []struct {
+		n    int64
+		want int64
+	}{
+		// Smallest positive int64 value not representable as a float64.
+		{n: 9007199254740993, want: 9007199254740994},
+		// Largest negative int64 value not representable as a float64.
+		{n: -9007199254740993, want: -9007199254740992},
+		// Testing non-representable int64 values that lie between arbitrary float64 gap.
+		{n: 8646911284551352321, want: 8646911284551353344},
+		{n: 8646911284551353343, want: 8646911284551353344},
+		{n: -8646911284551352321, want: -8646911284551352320},
+		{n: -8646911284551353343, want: -8646911284551352320},
+	} {
+		got := int64(nextLargerFloat64(tc.n))
+		if got != tc.want {
+			t.Errorf("nextLargerFloat64(%d) = %d, want %d", tc.n, got, tc.want)
+		}
+	}
+
+	// Casting math.MaxInt64 to float64 should result in the next larger float64 i.e 2^63.
+	// This equality has to be done in float64.
+	got := nextLargerFloat64(math.MaxInt64)
+	want := float64(1 << 63)
+	if got != want {
+		t.Errorf("nextLargerFloat64(%d) = %f, want %f", math.MaxInt64, got, want)
+	}
+}
+
+func TestNextSmallerFloat64InputRepresentableAsFloat64(t *testing.T) {
+	// Verify that nextSmallerFloat64 returns a float64 of the same value.
+	for _, x := range []int64{
+		0,
+		1,
+		-1,
+		// Smallest positive float64 for which next float64 is a distance of 2 away.
+		9007199254740992,
+		// Largest negative float64 for which previous float64 is a distance of 2 away.
+		-9007199254740992,
+		// Arbitrary representable number.
+		8646911284551352320,
+		-8646911284551352320,
+		// Largest int64 value accurately representable as a float64.
+		math.MaxInt64 - 1023,
+		// Smallest int64 value accurately representable as a float64.
+		math.MinInt64,
+	} {
+		got := int64(nextSmallerFloat64(x))
+		if got != x {
+			t.Errorf("nextSmallerFloat64(%d) = %d, want %d", x, got, x)
+		}
+	}
+}
+
+func TestNextSmallerFloat64InputNotRepresentableAsFloat64(t *testing.T) {
+	// Verify that nextSmallerFloat64 computes the closest float64 value that is smaller than
+	// or equal to the provided int64 value.
+	for _, tc := range []struct {
+		n    int64
+		want int64
+	}{
+		// Smallest positive int64 value not representable as a float64.
+		{n: 9007199254740993, want: 9007199254740992},
+		// Largest negative int64 value not representable as a float64.
+		{n: -9007199254740993, want: -9007199254740994},
+		// Testing non-representable int64 values that lie between arbitrary float64 gap.
+		{n: 8646911284551352321, want: 8646911284551352320},
+		{n: 8646911284551353343, want: 8646911284551352320},
+		{n: -8646911284551352321, want: -8646911284551353344},
+		{n: -8646911284551353343, want: -8646911284551353344},
+	} {
+		got := int64(nextSmallerFloat64(tc.n))
+		if got != tc.want {
+			t.Errorf("nextSmallerFloat64(%d) = %d, want %d", tc.n, got, tc.want)
+		}
+	}
+}

--- a/java/main/com/google/privacy/differentialprivacy/GaussianNoise.java
+++ b/java/main/com/google/privacy/differentialprivacy/GaussianNoise.java
@@ -218,7 +218,8 @@ public class GaussianNoise implements Noise {
    * <p>This implementation uses a binary search. Its runtime is rougly log(GAUSSIAN_SIGMA_ACCURACY)
    * + log(max{sigma_tight / l2sensitivity, l2sensitivity / sigma_tight}).
    */
-  private static double getSigma(double l2Sensitivity, double epsilon, double delta) {
+  @VisibleForTesting
+  double getSigma(double l2Sensitivity, double epsilon, double delta) {
     // We use l2sensitivity as a starting guess for the upper bound, since the required noise grows
     // linearly with sensitivity.
     double upperBound = l2Sensitivity;


### PR DESCRIPTION
Overall fixes and improvements to confidence intervals in Go/Java.
Golang:
    - Add nextSmallerFloat64 and nextLargerFloat64 functions
    - Edit Laplace's confidence interval checks to use checkEpsilonVeryStrict
    - Improvments to confidence interval noise tests

  Java:
    - Mock getSigma computation to return an accurate sigma value for confidence interval gaussian tests.