### PR TITLE
Golang: Minor fixes and improvements

### DIFF
--- a/go/dpagg/sum.go
+++ b/go/dpagg/sum.go
@@ -262,7 +262,7 @@ func (bs *BoundedSumInt64) ThresholdedResult(thresholdDelta float64) *int64 {
 // See https://github.com/google/differential-privacy/tree/main/common_docs/confidence_intervals.md.
 func (bs *BoundedSumInt64) ComputeConfidenceInterval(alpha float64) (noise.ConfidenceInterval, error) {
 	if !bs.resultReturned {
-		return noise.ConfidenceInterval{}, fmt.Errorf("You need to call Result() before calling ComputeConfidenceInterval()")
+		return noise.ConfidenceInterval{}, fmt.Errorf("Result() must be called before calling ComputeConfidenceInterval()")
 	}
 	confInt, err := bs.noise.ComputeConfidenceIntervalInt64(bs.noisedSum, bs.l0Sensitivity, bs.lInfSensitivity, bs.epsilon, bs.delta, alpha)
 	if err != nil {

--- a/go/noise/gaussian_noise_test.go
+++ b/go/noise/gaussian_noise_test.go
@@ -589,7 +589,31 @@ func TestComputeConfidenceIntervalInt64Gaussian(t *testing.T) {
 			want:            ConfidenceInterval{-5, 7},
 			wantErr:         false,
 		},
-		// Testing checkArgsConfidenceIntervalGaussian.
+		// Tests for nextSmallerFloat64 and nextLargerFloat64.
+		{
+			desc: "Large positive noisedX",
+			// Distance to neighbouring float64 values is greater than half the size of the confidence interval.
+			noisedX:         (1 << 58),
+			l0Sensitivity:   1,
+			lInfSensitivity: 1,
+			epsilon:         0.1,
+			delta:           0.1,
+			alpha:           0.1,
+			want:            ConfidenceInterval{math.Nextafter(1<<58, math.Inf(-1)), math.Nextafter(1<<58, math.Inf(1))},
+			wantErr:         false,
+		},
+		{
+			desc: "Large negative noisedX",
+			// Distance to neighbouring float64 values is greater than half the size of the confidence interval.
+			noisedX:         -(1 << 58),
+			l0Sensitivity:   1,
+			lInfSensitivity: 1,
+			epsilon:         0.1,
+			delta:           0.1,
+			alpha:           0.1,
+			want:            ConfidenceInterval{math.Nextafter(-1<<58, math.Inf(-1)), math.Nextafter(-1<<58, math.Inf(1))},
+			wantErr:         false,
+		},
 		{
 			desc:            "Arbitrary test with high alpha",
 			noisedX:         70.0,
@@ -612,6 +636,7 @@ func TestComputeConfidenceIntervalInt64Gaussian(t *testing.T) {
 			want:            ConfidenceInterval{-97, 237},
 			wantErr:         false,
 		},
+		// Testing checkArgsConfidenceIntervalGaussian.
 		{
 			desc:            "Testing alpha bigger than 1",
 			noisedX:         1,
@@ -856,6 +881,41 @@ func TestComputeConfidenceIntervalFloat64Gaussian(t *testing.T) {
 			want:            ConfidenceInterval{-96.6140883158, 236.6140883158},
 			wantErr:         false,
 		},
+		// Testing that bounds are accurate for abs(bound) < 2^53
+		{
+			desc:            "Large positive noisedX",
+			noisedX:         958655.4745,
+			l0Sensitivity:   1,
+			lInfSensitivity: 1,
+			epsilon:         0.1,
+			delta:           0.1,
+			alpha:           0.1,
+			want:            ConfidenceInterval{958650.79, 958660.16},
+			wantErr:         false,
+		},
+		{
+			desc:            "Large negative noisedX",
+			noisedX:         -958655.4745,
+			l0Sensitivity:   1,
+			lInfSensitivity: 1,
+			epsilon:         0.1,
+			delta:           0.1,
+			alpha:           0.1,
+			want:            ConfidenceInterval{-958660.16, -958650.79},
+			wantErr:         false,
+		},
+		{
+			desc:            "Arbitrary test",
+			noisedX:         699.2402199905,
+			l0Sensitivity:   1,
+			lInfSensitivity: 5,
+			epsilon:         0.333,
+			delta:           0.9,
+			alpha:           0.001256458,
+			want:            ConfidenceInterval{694.5583238637953, 703.9221161172047},
+			wantErr:         false,
+		},
+		// Testing checkArgsConfidenceIntervalGaussian
 		{
 			desc:            "Arbitrary test with 0 alpha",
 			noisedX:         598.21547558328,
@@ -878,18 +938,6 @@ func TestComputeConfidenceIntervalFloat64Gaussian(t *testing.T) {
 			want:            ConfidenceInterval{},
 			wantErr:         true,
 		},
-		{
-			desc:            "Arbitrary test",
-			noisedX:         699.2402199905,
-			l0Sensitivity:   1,
-			lInfSensitivity: 5,
-			epsilon:         0.333,
-			delta:           0.9,
-			alpha:           0.001256458,
-			want:            ConfidenceInterval{694.5583238637953, 703.9221161172047},
-			wantErr:         false,
-		},
-		// Testing checkArgsConfidenceIntervalGaussian
 		{
 			desc:            "Testing alpha bigger than 1",
 			noisedX:         1,
@@ -1062,11 +1110,11 @@ func TestComputeConfidenceIntervalFloat64Gaussian(t *testing.T) {
 		}
 		if !approxEqual(got.LowerBound, tc.want.LowerBound) {
 			t.Errorf("TestComputeConfidenceIntervalFloat64(%f, %d, %f, %f, %f)=%0.10f, want %0.10f, desc %s, LowerBound is not equal",
-				tc.noisedX, tc.l0Sensitivity, tc.lInfSensitivity, tc.epsilon, tc.alpha, got.UpperBound, tc.want.UpperBound, tc.desc)
+				tc.noisedX, tc.l0Sensitivity, tc.lInfSensitivity, tc.epsilon, tc.alpha, got.LowerBound, tc.want.LowerBound, tc.desc)
 		}
 		if !approxEqual(got.UpperBound, tc.want.UpperBound) {
 			t.Errorf("TestComputeConfidenceIntervalFloat64(%f, %d, %f, %f, %f)=%0.10f, want %0.10f, desc %s, UpperBound is not equal",
-				tc.noisedX, tc.l0Sensitivity, tc.lInfSensitivity, tc.epsilon, tc.alpha, got.LowerBound, tc.want.LowerBound, tc.desc)
+				tc.noisedX, tc.l0Sensitivity, tc.lInfSensitivity, tc.epsilon, tc.alpha, got.UpperBound, tc.want.UpperBound, tc.desc)
 		}
 	}
 }

--- a/go/noise/laplace_noise_test.go
+++ b/go/noise/laplace_noise_test.go
@@ -305,6 +305,25 @@ func TestComputeConfidenceIntervalFloat64Laplace(t *testing.T) {
 			alpha:           0.2,
 			want:            ConfidenceInterval{15.35478992, 61.49201008},
 		},
+		// Testing that bounds are accurate for abs(bound) < 2^53
+		{
+			desc:            "Large positive noisedX",
+			noisedX:         958655.4745,
+			l0Sensitivity:   1,
+			lInfSensitivity: 1.0,
+			epsilon:         0.1,
+			alpha:           0.1,
+			want:            ConfidenceInterval{958632.45, 958678.50},
+		},
+		{
+			desc:            "Large negative noisedX",
+			noisedX:         -958655.4745,
+			l0Sensitivity:   1,
+			lInfSensitivity: 1.0,
+			epsilon:         0.1,
+			alpha:           0.1,
+			want:            ConfidenceInterval{-958678.50, -958632.45},
+		},
 		// Argument checking
 		{
 			desc:            "Zero l0Sensitivity",
@@ -367,11 +386,11 @@ func TestComputeConfidenceIntervalFloat64Laplace(t *testing.T) {
 			wantErr:         true,
 		},
 		{
-			desc:            "Zero epsilon",
+			desc:            "Epsilon less than 2^-50",
 			noisedX:         0,
 			l0Sensitivity:   1,
 			lInfSensitivity: 1,
-			epsilon:         0,
+			epsilon:         1.0 / (1 << 51),
 			alpha:           0.5,
 			want:            ConfidenceInterval{},
 			wantErr:         true,
@@ -501,6 +520,27 @@ func TestComputeConfidenceIntervalInt64Laplace(t *testing.T) {
 			alpha:           0.8,
 			want:            ConfidenceInterval{-79, 55},
 		},
+		// Tests for nextSmallerFloat64 and nextLargerFloat64.
+		{
+			desc: "Large positive noisedX",
+			// Distance to neighbouring float64 values is greater than half the size of the confidence interval.
+			noisedX:         (1 << 58),
+			l0Sensitivity:   1,
+			lInfSensitivity: 1,
+			epsilon:         0.1,
+			alpha:           0.1,
+			want:            ConfidenceInterval{math.Nextafter(1<<58, math.Inf(-1)), math.Nextafter(1<<58, math.Inf(1))},
+		},
+		{
+			desc: "Large negative noisedX",
+			// Distance to neighbouring float64 values is greater than half the size of the confidence interval.
+			noisedX:         -(1 << 58),
+			l0Sensitivity:   1,
+			lInfSensitivity: 1,
+			epsilon:         0.1,
+			alpha:           0.1,
+			want:            ConfidenceInterval{math.Nextafter(-1<<58, math.Inf(-1)), math.Nextafter(-1<<58, math.Inf(1))},
+		},
 		// Argument checking
 		{
 			desc:            "Zero l0Sensitivity",
@@ -543,11 +583,11 @@ func TestComputeConfidenceIntervalInt64Laplace(t *testing.T) {
 			wantErr:         true,
 		},
 		{
-			desc:            "Zero epsilon",
+			desc:            "Epsilon less than 2^-50",
 			noisedX:         0,
 			l0Sensitivity:   1,
 			lInfSensitivity: 1,
-			epsilon:         0,
+			epsilon:         1.0 / (1 << 51),
 			alpha:           0.5,
 			want:            ConfidenceInterval{},
 			wantErr:         true,

--- a/go/noise/secure_noise_math.go
+++ b/go/noise/secure_noise_math.go
@@ -64,3 +64,38 @@ func ceilPowerOfTwo(x float64) float64 {
 func roundToMultipleOfPowerOfTwo(x, granularity float64) float64 {
 	return math.Round(x/granularity) * granularity
 }
+
+// nextLargerFloat64 computes the closest float64 value that is larger than or equal to the provided int64 value.
+//
+// Mapping from int64 to float64 for large int64 values (> 2^53) is inaccurate since they cannot be
+// represented as a float64. Implicit/explicit conversion from int64 to float64 either rounds up or
+// down the int64 value to the nearest representable float64. This function ensures that int64 n <=
+// float64 nextLargerFloat64(n)
+func nextLargerFloat64(n int64) float64 {
+	// Large int64 values n may lie between two representable float64 values a and b,
+	// i.e., a < n < b, (note that in this case a and b are guaranteed to be integers).
+	// If the standard conversion to float64 rounds the int64 value down, e.g. float64(n) = a,
+	// the difference a - n will be negative, indicating that the result needs to be incremented
+	// to the next float64 value b.
+	result := float64(n)
+	diff := int64(result) - n
+	if diff < 0 {
+		return math.Nextafter(result, math.Inf(1))
+	}
+	return result
+}
+
+// nextSmallerFloat64 computes the closest float64 value that is smaller than or equal to the provided int64 value.
+func nextSmallerFloat64(n int64) float64 {
+	// Large int64 values n may lie between two representable float64 values a and b,
+	// i.e., a < n < b, (note that in this case a and b are guaranteed to be integers).
+	// If the standard conversion to float64 rounds the int64 value up, e.g. int64(n) = b,
+	// the difference b - n will be positive, indicating that the result needs to be decremented
+	// to the previous float64 value a.
+	result := float64(n)
+	diff := int64(result) - n
+	if diff > 0 {
+		return math.Nextafter(result, math.Inf(-1))
+	}
+	return result
+}

--- a/go/noise/secure_noise_math_test.go
+++ b/go/noise/secure_noise_math_test.go
@@ -257,3 +257,109 @@ func TestRoundToMultipleOfPowerOfTwoXIsNotAMultiple(t *testing.T) {
 		}
 	}
 }
+
+func TestNextLargerFloat64InputRepresentableAsFloat64(t *testing.T) {
+	// Verify that nextLargerFloat64 returns a float64 of the same value.
+	for _, x := range []int64{
+		0,
+		1,
+		-1,
+		// Smallest positive float64 for which next float64 is a distance of 2 away.
+		9007199254740992,
+		// Largest negative float64 for which previous float64 is a distance of 2 away.
+		-9007199254740992,
+		// Arbitrary representable number.
+		8646911284551352320,
+		-8646911284551352320,
+		// Largest int64 value accurately representable as a float64.
+		math.MaxInt64 - 1023,
+		// Smallest int64 value accurately representable as a float64.
+		math.MinInt64,
+	} {
+		got := int64(nextLargerFloat64(x))
+		if got != x {
+			t.Errorf("nextLargerFloat64(%d) = %d, want %d", x, got, x)
+		}
+	}
+}
+
+func TestNextLargerFloat64InputNotRepresentableAsFloat64(t *testing.T) {
+	// Verify that nextLargerFloat64 computes the closest float64 value that is larger than
+	// or equal to the provided int64 value.
+	for _, tc := range []struct {
+		n    int64
+		want int64
+	}{
+		// Smallest positive int64 value not representable as a float64.
+		{n: 9007199254740993, want: 9007199254740994},
+		// Largest negative int64 value not representable as a float64.
+		{n: -9007199254740993, want: -9007199254740992},
+		// Testing non-representable int64 values that lie between arbitrary float64 gap.
+		{n: 8646911284551352321, want: 8646911284551353344},
+		{n: 8646911284551353343, want: 8646911284551353344},
+		{n: -8646911284551352321, want: -8646911284551352320},
+		{n: -8646911284551353343, want: -8646911284551352320},
+	} {
+		got := int64(nextLargerFloat64(tc.n))
+		if got != tc.want {
+			t.Errorf("nextLargerFloat64(%d) = %d, want %d", tc.n, got, tc.want)
+		}
+	}
+
+	// Casting math.MaxInt64 to float64 should result in the next larger float64 i.e 2^63.
+	// This equality has to be done in float64.
+	got := nextLargerFloat64(math.MaxInt64)
+	want := float64(1 << 63)
+	if got != want {
+		t.Errorf("nextLargerFloat64(%d) = %f, want %f", math.MaxInt64, got, want)
+	}
+}
+
+func TestNextSmallerFloat64InputRepresentableAsFloat64(t *testing.T) {
+	// Verify that nextSmallerFloat64 returns a float64 of the same value.
+	for _, x := range []int64{
+		0,
+		1,
+		-1,
+		// Smallest positive float64 for which next float64 is a distance of 2 away.
+		9007199254740992,
+		// Largest negative float64 for which previous float64 is a distance of 2 away.
+		-9007199254740992,
+		// Arbitrary representable number.
+		8646911284551352320,
+		-8646911284551352320,
+		// Largest int64 value accurately representable as a float64.
+		math.MaxInt64 - 1023,
+		// Smallest int64 value accurately representable as a float64.
+		math.MinInt64,
+	} {
+		got := int64(nextSmallerFloat64(x))
+		if got != x {
+			t.Errorf("nextSmallerFloat64(%d) = %d, want %d", x, got, x)
+		}
+	}
+}
+
+func TestNextSmallerFloat64InputNotRepresentableAsFloat64(t *testing.T) {
+	// Verify that nextSmallerFloat64 computes the closest float64 value that is smaller than
+	// or equal to the provided int64 value.
+	for _, tc := range []struct {
+		n    int64
+		want int64
+	}{
+		// Smallest positive int64 value not representable as a float64.
+		{n: 9007199254740993, want: 9007199254740992},
+		// Largest negative int64 value not representable as a float64.
+		{n: -9007199254740993, want: -9007199254740994},
+		// Testing non-representable int64 values that lie between arbitrary float64 gap.
+		{n: 8646911284551352321, want: 8646911284551352320},
+		{n: 8646911284551353343, want: 8646911284551352320},
+		{n: -8646911284551352321, want: -8646911284551353344},
+		{n: -8646911284551353343, want: -8646911284551353344},
+	} {
+		got := int64(nextSmallerFloat64(tc.n))
+		if got != tc.want {
+			t.Errorf("nextSmallerFloat64(%d) = %d, want %d", tc.n, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
- Add nextSmallerFloat64 and nextLargerFloat64 functions
- Edit Laplace's confidence interval checks to use checkEpsilonVeryStrict