### PR TITLE
Fix a rare privacy bug in DistinctPerKey in Privacy on Beam.

### DIFF
--- a/privacy-on-beam/pbeam/aggregations.go
+++ b/privacy-on-beam/pbeam/aggregations.go
@@ -42,8 +42,11 @@ func init() {
 	beam.RegisterType(reflect.TypeOf((*decodePairInt64Fn)(nil)))
 	beam.RegisterType(reflect.TypeOf((*decodePairFloat64Fn)(nil)))
 	beam.RegisterType(reflect.TypeOf((*dropValuesFn)(nil)))
+	beam.RegisterType(reflect.TypeOf((*encodeKVFn)(nil)))
 	beam.RegisterType(reflect.TypeOf((*encodeIDKFn)(nil)))
+	beam.RegisterType(reflect.TypeOf((*decodeIDKFn)(nil)))
 	beam.RegisterType(reflect.TypeOf((*expandValuesCombineFn)(nil)))
+	beam.RegisterType(reflect.TypeOf((*expandFloat64ValuesCombineFn)(nil)))
 	beam.RegisterType(reflect.TypeOf((*decodePairArrayFloat64Fn)(nil)))
 	beam.RegisterType(reflect.TypeOf((*partitionsMapFn)(nil)).Elem())
 	beam.RegisterType(reflect.TypeOf((*prunePartitionsVFn)(nil)).Elem())
@@ -736,6 +739,26 @@ func (fn *dropValuesFn) ProcessElement(id beam.Z, kv kv.Pair) (beam.Z, beam.W) {
 	return id, k
 }
 
+// encodeKVFn takes a PCollection<kv.Pair{ID,K}, codedV> as input, and returns a
+// PCollection<ID, kv.Pair{K,V}>; where K and V have been coded, and ID has been
+// decoded.
+type encodeKVFn struct {
+	InputPairCodec *kv.Codec // Codec for the input kv.Pair{ID,K}
+}
+
+func newEncodeKVFn(idkCodec *kv.Codec) *encodeKVFn {
+	return &encodeKVFn{InputPairCodec: idkCodec}
+}
+
+func (fn *encodeKVFn) Setup() error {
+	return fn.InputPairCodec.Setup()
+}
+
+func (fn *encodeKVFn) ProcessElement(pair kv.Pair, codedV []byte) (beam.W, kv.Pair) {
+	id, _ := fn.InputPairCodec.Decode(pair)
+	return id, kv.Pair{pair.V, codedV} // pair.V is the K in PCollection<kv.Pair{ID,K}, codedV>
+}
+
 // encodeIDKFn takes a PCollection<ID,kv.Pair{K,V}> as input, and returns a
 // PCollection<kv.Pair{ID,K},V>; where ID and K have been coded, and V has been
 // decoded.
@@ -764,6 +787,36 @@ func (fn *encodeIDKFn) ProcessElement(id beam.W, pair kv.Pair) (kv.Pair, beam.V)
 	}
 	_, v := fn.InputPairCodec.Decode(pair)
 	return kv.Pair{idBuf.Bytes(), pair.K}, v
+}
+
+// decodeIDKFn is the reverse operation of encodeIDKFn. It takes a PCollection<kv.Pair{ID,K},V>
+// as input, and returns a PCollection<ID, kv.Pair{K,V}>; where K and V has been coded, and ID
+// has been decoded.
+type decodeIDKFn struct {
+	VType          beam.EncodedType    // Type information of the value V
+	vEnc           beam.ElementEncoder // Encoder for privacy ID, set during Setup() according to VType
+	InputPairCodec *kv.Codec           // Codec for the input kv.Pair{ID,K}
+}
+
+func newDecodeIDKFn(vType typex.FullType, idkCodec *kv.Codec) *decodeIDKFn {
+	return &decodeIDKFn{
+		VType:          beam.EncodedType{vType.Type()},
+		InputPairCodec: idkCodec,
+	}
+}
+
+func (fn *decodeIDKFn) Setup() error {
+	fn.vEnc = beam.NewElementEncoder(fn.VType.T)
+	return fn.InputPairCodec.Setup()
+}
+
+func (fn *decodeIDKFn) ProcessElement(pair kv.Pair, v beam.V) (beam.W, kv.Pair, error) {
+	var vBuf bytes.Buffer
+	if err := fn.vEnc.Encode(v, &vBuf); err != nil {
+		return nil, kv.Pair{}, fmt.Errorf("pbeam.decodeIDKFn.ProcessElement: couldn't encode V %v: %w", v, err)
+	}
+	id, _ := fn.InputPairCodec.Decode(pair)
+	return id, kv.Pair{pair.V, vBuf.Bytes()}, nil // pair.V is the K in PCollection<kv.Pair{ID,K},V>
 }
 
 // decodePairArrayFloat64Fn transforms a PCollection<pairArrayFloat64<codedX,[]float64>> into a
@@ -862,21 +915,36 @@ func convertUint64ToFloat64Fn(z beam.Z, i uint64) (beam.Z, float64) {
 }
 
 type expandValuesAccum struct {
-	Values []float64
+	Values [][]byte
 }
 
-// expandValuesCombineFn converts a PCollection<K,float64> to PCollection<K,[]float64>
-// where each value corresponding to the same key are collected in a slice. Resulting
-// PCollection has a single slice for each key.
-type expandValuesCombineFn struct{}
+// expandValuesCombineFn converts a PCollection<K,V> to PCollection<K,[]V> where each value
+// corresponding to the same key are collected in a slice. Resulting PCollection has a
+// single slice for each key.
+type expandValuesCombineFn struct {
+	VType beam.EncodedType
+	vEnc  beam.ElementEncoder
+}
+
+func newExpandValuesCombineFn(vType beam.EncodedType) *expandValuesCombineFn {
+	return &expandValuesCombineFn{VType: vType}
+}
+
+func (fn *expandValuesCombineFn) Setup() {
+	fn.vEnc = beam.NewElementEncoder(fn.VType.T)
+}
 
 func (fn *expandValuesCombineFn) CreateAccumulator() expandValuesAccum {
-	return expandValuesAccum{Values: make([]float64, 0)}
+	return expandValuesAccum{Values: make([][]byte, 0)}
 }
 
-func (fn *expandValuesCombineFn) AddInput(a expandValuesAccum, value float64) expandValuesAccum {
-	a.Values = append(a.Values, value)
-	return a
+func (fn *expandValuesCombineFn) AddInput(a expandValuesAccum, value beam.V) (expandValuesAccum, error) {
+	var vBuf bytes.Buffer
+	if err := fn.vEnc.Encode(value, &vBuf); err != nil {
+		return a, fmt.Errorf("pbeam.expandValuesCombineFn.AddInput: couldn't encode V %v: %w", value, err)
+	}
+	a.Values = append(a.Values, vBuf.Bytes())
+	return a, nil
 }
 
 func (fn *expandValuesCombineFn) MergeAccumulators(a, b expandValuesAccum) expandValuesAccum {
@@ -884,7 +952,34 @@ func (fn *expandValuesCombineFn) MergeAccumulators(a, b expandValuesAccum) expan
 	return a
 }
 
-func (fn *expandValuesCombineFn) ExtractOutput(a expandValuesAccum) []float64 {
+func (fn *expandValuesCombineFn) ExtractOutput(a expandValuesAccum) [][]byte {
+	return a.Values
+}
+
+type expandFloat64ValuesAccum struct {
+	Values []float64
+}
+
+// expandFloat64ValuesCombineFn converts a PCollection<K,float64> to PCollection<K,[]float64>
+// where each value corresponding to the same key are collected in a slice. Resulting
+// PCollection has a single slice for each key.
+type expandFloat64ValuesCombineFn struct{}
+
+func (fn *expandFloat64ValuesCombineFn) CreateAccumulator() expandFloat64ValuesAccum {
+	return expandFloat64ValuesAccum{Values: make([]float64, 0)}
+}
+
+func (fn *expandFloat64ValuesCombineFn) AddInput(a expandFloat64ValuesAccum, value float64) expandFloat64ValuesAccum {
+	a.Values = append(a.Values, value)
+	return a
+}
+
+func (fn *expandFloat64ValuesCombineFn) MergeAccumulators(a, b expandFloat64ValuesAccum) expandFloat64ValuesAccum {
+	a.Values = append(a.Values, b.Values...)
+	return a
+}
+
+func (fn *expandFloat64ValuesCombineFn) ExtractOutput(a expandFloat64ValuesAccum) []float64 {
 	return a.Values
 }
 

--- a/privacy-on-beam/pbeam/coders.go
+++ b/privacy-on-beam/pbeam/coders.go
@@ -33,6 +33,7 @@ func init() {
 	beam.RegisterCoder(reflect.TypeOf(boundedMeanAccumFloat64{}), encodeBoundedMeanAccumFloat64, decodeBoundedMeanAccumFloat64)
 	beam.RegisterCoder(reflect.TypeOf(boundedQuantilesAccum{}), encodeBoundedQuantilesAccum, decodeBoundedQuantilesAccum)
 	beam.RegisterCoder(reflect.TypeOf(expandValuesAccum{}), encodeExpandValuesAccum, decodeExpandValuesAccum)
+	beam.RegisterCoder(reflect.TypeOf(expandFloat64ValuesAccum{}), encodeExpandFloat64ValuesAccum, decodeExpandFloat64ValuesAccum)
 	beam.RegisterCoder(reflect.TypeOf(partitionSelectionAccum{}), encodePartitionSelectionAccum, decodePartitionSelectionAccum)
 }
 
@@ -92,6 +93,16 @@ func encodeExpandValuesAccum(v expandValuesAccum) ([]byte, error) {
 
 func decodeExpandValuesAccum(data []byte) (expandValuesAccum, error) {
 	var ret expandValuesAccum
+	err := decode(&ret, data)
+	return ret, err
+}
+
+func encodeExpandFloat64ValuesAccum(v expandFloat64ValuesAccum) ([]byte, error) {
+	return encode(v)
+}
+
+func decodeExpandFloat64ValuesAccum(data []byte) (expandFloat64ValuesAccum, error) {
+	var ret expandFloat64ValuesAccum
 	err := decode(&ret, data)
 	return ret, err
 }

--- a/privacy-on-beam/pbeam/mean.go
+++ b/privacy-on-beam/pbeam/mean.go
@@ -168,7 +168,7 @@ func MeanPerKey(s beam.Scope, pcol PrivatePCollection, params MeanParams) beam.P
 	// Combine all values for <id, partition> into a slice.
 	// Result is PCollection<kv.Pair{ID,K},[]float64>.
 	combined := beam.CombinePerKey(s,
-		&expandValuesCombineFn{},
+		&expandFloat64ValuesCombineFn{},
 		converted)
 
 	// Result is PCollection<ID, pairArrayFloat64>.

--- a/privacy-on-beam/pbeam/quantiles.go
+++ b/privacy-on-beam/pbeam/quantiles.go
@@ -184,7 +184,7 @@ func QuantilesPerKey(s beam.Scope, pcol PrivatePCollection, params QuantilesPara
 	// Combine all values for <id, partition> into a slice.
 	// Result is PCollection<kv.Pair{ID,K},[]float64>.
 	combined := beam.CombinePerKey(s,
-		&expandValuesCombineFn{},
+		&expandFloat64ValuesCombineFn{},
 		converted)
 
 	// Result is PCollection<ID, pairArrayFloat64>.


### PR DESCRIPTION
The bug occurred when there are outlier users in the input that
contribute to many partitions or to many values AND the values
contributed are the same as values from other users (the second part
is critical, if the contributed values only come from a single user then
the bug does not occur). Then, the output might not have be DP due to
incorrect contribution bounding. See the comments in the newly added
tests for concrete examples of when/how the bug used to occur.

This is cherry-picked from the main branch commit
e149618d032f97b476fecc5839a278cc680def08.

This commit includes a minor change compared to the one on the main
branch: It removes the error output for kv.Codec.Encode/Decode
functions used in aggregations.go since the error output for these
functions weren't implemented in v1.0.0.