### PR TITLE
C++: Fix multiple contributions for implicit ApproxBounds

### DIFF
--- a/cc/algorithms/approx-bounds.h
+++ b/cc/algorithms/approx-bounds.h
@@ -388,6 +388,10 @@ class ApproxBounds : public Algorithm<T> {
     return report;
   }
 
+  // Returns a pointer to the mechanism for testing.  Does not transfer
+  // ownership.
+  NumericalMechanism* GetMechanismForTesting() { return mechanism_.get(); }
+
  protected:
   ApproxBounds(double epsilon, int64_t num_bins, double scale, double base,
                double k, bool preset_k,

--- a/cc/algorithms/bounded-algorithm.h
+++ b/cc/algorithms/bounded-algorithm.h
@@ -97,10 +97,18 @@ class BoundedAlgorithmBuilder : public AlgorithmBuilder<T, Algorithm, Builder> {
       remaining_epsilon_ =
           AlgorithmBuilder::GetEpsilon().value() - bounds_epsilon;
       auto mech_builder = AlgorithmBuilder::GetMechanismBuilderClone();
+      const int max_partitions_contributed =
+          AlgorithmBuilder::GetMaxPartitionsContributed().value_or(1);
+      const int max_contributions_per_partition =
+          AlgorithmBuilder::GetMaxContributionsPerPartition().value_or(1);
       ASSIGN_OR_RETURN(approx_bounds_,
                        typename ApproxBounds<T>::Builder()
                            .SetEpsilon(bounds_epsilon)
                            .SetLaplaceMechanism(std::move(mech_builder))
+                           .SetMaxPartitionsContributed(
+                               max_partitions_contributed)
+                           .SetMaxContributionsPerPartition(
+                               max_contributions_per_partition)
                            .Build());
     }
     return absl::OkStatus();

--- a/cc/algorithms/bounded-sum.h
+++ b/cc/algorithms/bounded-sum.h
@@ -325,6 +325,9 @@ class BoundedSumWithApproxBounds : public BoundedSum<T> {
     return memory;
   }
 
+  // Returns the ApproxBounds for testing.  Does not transfer ownership.
+  ApproxBounds<T>* GetApproxBoundsForTesting() { return approx_bounds_.get(); }
+
  protected:
   base::StatusOr<Output> GenerateResult(double privacy_budget,
                                         double noise_interval_level) override {


### PR DESCRIPTION
This is a backport of the fix in the main branch
ae9c6b6d5b7e772837ae336d1b3092683481ec16

This change contains a critical fix for cases where ApproxBounds is used
implicitly (not specified in the builder) and we use multiple
contributions per user or multiple contributions per partition for sum,
mean, variance, and stddev.