### PR TITLE
Golang: fix confidence interval calculations with the correct confidence level

### DIFF
--- a/go/dpagg/mean.go
+++ b/go/dpagg/mean.go
@@ -274,11 +274,11 @@ func (bm *BoundedMeanFloat64) ComputeConfidenceInterval(alpha float64) (noise.Co
 // Result() needs to be called before ComputeConfidenceInterval, otherwise this will return an error.
 func (bm *BoundedMeanFloat64) computeConfidenceIntervalForExplicitAlphaNum(alpha, alphaNum float64) (noise.ConfidenceInterval, error) {
 	alphaDen := (alpha - alphaNum) / (1 - alphaNum) // setting alphaDen such that (1 - alpha) = (1 - alphaNum) * (1 - alphaDen)
-	confIntNum, err := bm.NormalizedSum.ComputeConfidenceInterval(alphaDen)
+	confIntNum, err := bm.NormalizedSum.ComputeConfidenceInterval(alphaNum)
 	if err != nil {
 		return noise.ConfidenceInterval{}, err
 	}
-	confIntDen, err := bm.Count.ComputeConfidenceInterval(alphaNum)
+	confIntDen, err := bm.Count.ComputeConfidenceInterval(alphaDen)
 	if err != nil {
 		return noise.ConfidenceInterval{}, err
 	}


### PR DESCRIPTION
Fixed confidence interval for the numerator because it was calculated using the confidence level for the denominator in Golang's mean implementation. The same was true for the confidence interval for the denominator.

This corresponds to the Java code [here](https://github.com/google/differential-privacy/blob/d51eedc0beea536ea563ade62116f37633eebf4d/java/main/com/google/privacy/differentialprivacy/BoundedMean.java#L230-L231).