### PR TITLE
Added operator overloads for PLD composition.

### DIFF
--- a/python/dp_accounting/privacy_loss_distribution.py
+++ b/python/dp_accounting/privacy_loss_distribution.py
@@ -657,6 +657,14 @@ class PrivacyLossDistribution:
     pmf_add = self._pmf_add.self_compose(num_times, tail_mass_truncation)
     return PrivacyLossDistribution(pmf_remove, pmf_add)
 
+  def __add__(self, other: 'PrivacyLossDistribution') -> 'PrivacyLossDistribution':
+    return self.compose(other)
+
+  def __mul__(self, num_times: int) -> 'PrivacyLossDistribution':
+    return self.self_compose(num_times)
+
+  __rmul__ = __mul__
+
 
 def identity(
     value_discretization_interval: float = 1e-4) -> PrivacyLossDistribution:

--- a/python/dp_accounting/privacy_loss_distribution_basic_example.py
+++ b/python/dp_accounting/privacy_loss_distribution_basic_example.py
@@ -34,7 +34,8 @@ def main(argv):
   # Number of times Laplace Mechanism is run
   num_laplace = 40
   # PLD for num_laplace executions of the Laplace Mechanism.
-  composed_laplace_pld = laplace_pld.self_compose(num_laplace)
+  #composed_laplace_pld = laplace_pld.self_compose(num_laplace)
+  composed_laplace_pld = laplace_pld * num_laplace
 
   epsilon = 10
   delta = composed_laplace_pld.get_delta_for_epsilon(epsilon)
@@ -53,7 +54,8 @@ def main(argv):
 
   # PLD for num_laplace executions of the Laplace Mechanism and one execution of
   # the Gaussian Mechanism.
-  composed_laplace_and_gaussian_pld = composed_laplace_pld.compose(gaussian_pld)
+  #composed_laplace_and_gaussian_pld = composed_laplace_pld.compose(gaussian_pld)
+  composed_laplace_and_gaussian_pld = composed_laplace_pld + gaussian_pld
 
   epsilon = 10
   delta = composed_laplace_and_gaussian_pld.get_delta_for_epsilon(epsilon)


### PR DESCRIPTION
Suggestion:
Simple composition of `pld1`, `pld2` can now be expressed using `pld1 + pld2`,
`k`-fold self-compositition as `k * pld1`. This allows for easy-to-read
construction of complex PLD compositions, e.g.,
`pld = k12 * (k1 * pld1 + pld2) + k3 * pld3`
instead of
`pld = pld1.self_compose(k1).compose(pld2).self_compose(k12).compose(pld3.self_compose(k3))`.