### PR TITLE
Update rules jvm external to 4.4.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+**/bazel-bin
+**/bazel-java
+**/bazel-out
+**/bazel-testlogs

--- a/java/.gitignore
+++ b/java/.gitignore
@@ -1,0 +1,4 @@
+bazel-bin
+bazel-java
+bazel-out
+bazel-testlogs

--- a/java/.gitignore
+++ b/java/.gitignore
@@ -1,4 +1,0 @@
-bazel-bin
-bazel-java
-bazel-out
-bazel-testlogs

--- a/java/WORKSPACE.bazel
+++ b/java/WORKSPACE.bazel
@@ -20,18 +20,19 @@ local_repository(
     name = "com_google_differential_privacy",
     path = "..",
 )
+
 # Load maven rules.
 load("@com_google_java_differential_privacy//:dp_java_deps_preload.bzl", "dp_java_deps_prework")
 dp_java_deps_prework()
-
-load("@com_google_java_differential_privacy//:dp_java_deps.bzl", "dp_java_deps")
-dp_java_deps()
 
 load("@rules_jvm_external//:repositories.bzl", "rules_jvm_external_deps")
 rules_jvm_external_deps()
 
 load("@rules_jvm_external//:setup.bzl", "rules_jvm_external_setup")
 rules_jvm_external_setup()
+
+load("@com_google_java_differential_privacy//:dp_java_deps.bzl", "dp_java_deps")
+dp_java_deps()
 
 # Load dependencies for the base workspace.
 load("@com_google_differential_privacy//:differential_privacy_deps.bzl", "differential_privacy_deps")

--- a/java/WORKSPACE.bazel
+++ b/java/WORKSPACE.bazel
@@ -20,15 +20,6 @@ local_repository(
     name = "com_google_differential_privacy",
     path = "..",
 )
-
-# Load dependencies for the base workspace.
-load("@com_google_differential_privacy//:differential_privacy_deps.bzl", "differential_privacy_deps")
-differential_privacy_deps()
-
-# Protobuf transitive dependencies.
-load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
-protobuf_deps()
-
 # Load maven rules.
 load("@com_google_java_differential_privacy//:dp_java_deps_preload.bzl", "dp_java_deps_prework")
 dp_java_deps_prework()
@@ -41,6 +32,14 @@ rules_jvm_external_deps()
 
 load("@rules_jvm_external//:setup.bzl", "rules_jvm_external_setup")
 rules_jvm_external_setup()
+
+# Load dependencies for the base workspace.
+load("@com_google_differential_privacy//:differential_privacy_deps.bzl", "differential_privacy_deps")
+differential_privacy_deps()
+
+# Protobuf transitive dependencies.
+load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
+protobuf_deps()
 
 # Complete pinning after defining dependencies.
 load("@maven//:defs.bzl", "pinned_maven_install")

--- a/java/dp_java_deps_preload.bzl
+++ b/java/dp_java_deps_preload.bzl
@@ -7,15 +7,20 @@ def dp_java_deps_prework():
 
         This must be called before the rest of the dependencies are loaded.
     """
+    RULES_JVM_EXTERNAL_TAG = "4.4.2"
+    RULES_JVM_EXTERNAL_SHA = "735602f50813eb2ea93ca3f5e43b1959bd80b213b836a07a62a29d757670b77b"
+    BAZEL_COMMON_TAG = "3d0e5005cfcbee836e31695d4ab91b5328ccc506"
+    BAZEL_COMMON_SHA = "8dd4dd688b42148f2a87652901a4eb2c85c64834be7a6890ebfc8ef1f67eeeaa"
     http_archive(
         name = "rules_jvm_external",
-        sha256 = "995ea6b5f41e14e1a17088b727dcff342b2c6534104e73d6f06f1ae0422c2308",
-        url = "https://github.com/bazelbuild/rules_jvm_external/archive/4.1.tar.gz",
-        strip_prefix = "rules_jvm_external-4.1",
+        strip_prefix = "rules_jvm_external-%s" % RULES_JVM_EXTERNAL_TAG,
+        sha256 = RULES_JVM_EXTERNAL_SHA,
+        url = "https://github.com/bazelbuild/rules_jvm_external/archive/refs/tags/%s.zip" % RULES_JVM_EXTERNAL_TAG,
     )
     http_archive(
         name = "bazel_common",
-        url = "https://github.com/google/bazel-common/archive/3d0e5005cfcbee836e31695d4ab91b5328ccc506.tar.gz",
-        sha256 = "8dd4dd688b42148f2a87652901a4eb2c85c64834be7a6890ebfc8ef1f67eeeaa",
-        strip_prefix = "bazel-common-3d0e5005cfcbee836e31695d4ab91b5328ccc506",
+        url = "https://github.com/google/bazel-common/archive/%s.tar.gz" % BAZEL_COMMON_TAG,
+        sha256 = BAZEL_COMMON_SHA,
+        strip_prefix = "bazel-common-%s" % BAZEL_COMMON_TAG,
     )
+


### PR DESCRIPTION
Update Rules JVM External to version 4.4.2.  Also add a top level .gitignore file to ignore Bazel output.