### PR TITLE
Fix Accounting calibrate_dp_mechanism exception

### DIFF
--- a/python/dp_accounting/mechanism_calibration.py
+++ b/python/dp_accounting/mechanism_calibration.py
@@ -162,8 +162,8 @@ def calibrate_dp_mechanism(
                     f'found {type(make_fresh_accountant)}.')
 
   if not callable(make_event_from_param):
-    raise TypeError(f'make_fresh_accountant must be callable. '
-                    f'found {type(make_fresh_accountant)}.')
+    raise TypeError(f'make_event_from_param must be callable. '
+                    f'found {type(make_event_from_param)}.')
 
   if target_epsilon < 0:
     raise ValueError(f'target_epsilon must be nonnegative. Found '


### PR DESCRIPTION
The argument type checking in this function raises a TypeError that refers to the wrong argument