### PR TITLE
Spark kotlin setup JVM issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,8 @@
 **/bazel-java
 **/bazel-out
 **/bazel-testlogs
+
+//IntelliJ setup files
+pipelinedp4j/.ijwb/
+pipelinedp4j/MODULE.bazel
+pipelinedp4j/MODULE.bazel.lock

--- a/bazel-differential-privacy
+++ b/bazel-differential-privacy
@@ -1,0 +1,1 @@
+/private/var/tmp/_bazel_skkumar/7dc376abe2bdc4392852fcde3092e87c/execroot/com_google_differential_privacy

--- a/pipelinedp4j/BUILD.bazel
+++ b/pipelinedp4j/BUILD.bazel
@@ -38,6 +38,7 @@ pom_file(
     # Generate this list via `bazelisk query //main/...`
     targets = [
         "//main/com/google/privacy/differentialprivacy/pipelinedp4j/api:api",
+        "//main/com/google/privacy/differentialprivacy/pipelinedp4j/spark:spark_collections",
         "//main/com/google/privacy/differentialprivacy/pipelinedp4j/beam:beam_collections",
         "//main/com/google/privacy/differentialprivacy/pipelinedp4j/beam:beam_dp_engine_factory",
         "//main/com/google/privacy/differentialprivacy/pipelinedp4j/beam:beam_encoders",

--- a/pipelinedp4j/WORKSPACE.bazel
+++ b/pipelinedp4j/WORKSPACE.bazel
@@ -73,6 +73,12 @@ maven_install(
         "org.apache.beam:beam-sdks-java-core:2.49.0",
         "org.apache.beam:beam-sdks-java-extensions-avro:2.49.0",
         "org.apache.beam:beam-sdks-java-extensions-protobuf:2.49.0",
+
+        "org.apache.spark:spark-core_2.12:3.3.2",
+        "org.apache.spark:spark-sql_2.12:3.3.2",
+        "org.apache.spark:spark-mllib_2.12:3.3.2",
+        "org.apache.spark:spark-catalyst_2.12:3.3.2",
+
         # Test only dependencies.
         maven.artifact(
             "com.google.truth",

--- a/pipelinedp4j/bazel-pipelinedp4j
+++ b/pipelinedp4j/bazel-pipelinedp4j
@@ -1,0 +1,1 @@
+/private/var/tmp/_bazel_skkumar/816dcaefc3b95d3f6c5a29b993bbae5b/execroot/_main

--- a/pipelinedp4j/main/com/google/privacy/differentialprivacy/pipelinedp4j/spark/BUILD.bazel
+++ b/pipelinedp4j/main/com/google/privacy/differentialprivacy/pipelinedp4j/spark/BUILD.bazel
@@ -1,0 +1,49 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
+
+package(
+    default_visibility = [
+        "//visibility:public",
+    ],
+)
+
+kt_jvm_library(
+    name = "spark_encoders",
+    srcs = ["SparkEncoders.kt"],
+    deps = [
+        "//main/com/google/privacy/differentialprivacy/pipelinedp4j/core:encoders",
+        "@maven//:com_google_protobuf_protobuf_java",
+        "@maven//:org_apache_spark_spark_core_2_12",
+        "@maven//:org_apache_spark_spark_sql_2_12",
+        "@maven//:org_apache_spark_spark_mllib_2_12",
+        "@maven//:org_apache_spark_spark_catalyst_2_12",
+    ],
+)
+
+kt_jvm_library(
+    name = "spark_collections",
+    srcs = ["SparkCollection.kt"],
+    deps = [
+        ":spark_encoders",
+        "//main/com/google/privacy/differentialprivacy/pipelinedp4j/core:encoders",
+        "//main/com/google/privacy/differentialprivacy/pipelinedp4j/core:framework_collections",
+        "//main/com/google/privacy/differentialprivacy/pipelinedp4j/local:local_collections",
+         "@maven//:org_apache_spark_spark_core_2_12",
+         "@maven//:org_apache_spark_spark_sql_2_12",
+         "@maven//:org_apache_spark_spark_mllib_2_12",
+         "@maven//:org_apache_spark_spark_catalyst_2_12",
+    ],
+)

--- a/pipelinedp4j/main/com/google/privacy/differentialprivacy/pipelinedp4j/spark/SparkCollection.kt
+++ b/pipelinedp4j/main/com/google/privacy/differentialprivacy/pipelinedp4j/spark/SparkCollection.kt
@@ -1,0 +1,30 @@
+package com.google.privacy.differentialprivacy.pipelinedp4j.spark
+
+import com.google.privacy.differentialprivacy.pipelinedp4j.core.Encoder
+import com.google.privacy.differentialprivacy.pipelinedp4j.core.FrameworkCollection
+import com.google.privacy.differentialprivacy.pipelinedp4j.core.FrameworkTable
+import org.apache.spark.api.java.function.MapFunction
+import org.apache.spark.sql.Dataset
+
+class SparkCollection<T>(val data: Dataset<T>): FrameworkCollection<T>  {
+
+    override val elementsEncoder: SparkEncoder<T> = SparkEncoder<T>(data.encoder())
+
+    override fun distinct(stageName: String): FrameworkCollection<T> {
+        return SparkCollection(data.distinct())
+    }
+
+    override fun <K, V> mapToTable(stageName: String, keyType: Encoder<K>, valueType: Encoder<V>, mapFn: (T) -> Pair<K, V>): FrameworkTable<K, V> {
+        TODO("Not yet implemented")
+    }
+
+    override fun <K> keyBy(stageName: String, outputType: Encoder<K>, keyFn: (T) -> K): FrameworkTable<K, T> {
+        TODO("Not yet implemented")
+    }
+
+    override fun <R> map(stageName: String, outputType: Encoder<R>, mapFn: (T) -> R): FrameworkCollection<R> {
+        val outputCoder = (outputType as SparkEncoder<R>).encoder
+        val transformedData = data.map(MapFunction { mapFn(it) }, outputCoder)
+        return SparkCollection(transformedData)
+    }
+}

--- a/pipelinedp4j/main/com/google/privacy/differentialprivacy/pipelinedp4j/spark/SparkEncoders.kt
+++ b/pipelinedp4j/main/com/google/privacy/differentialprivacy/pipelinedp4j/spark/SparkEncoders.kt
@@ -1,0 +1,39 @@
+package com.google.privacy.differentialprivacy.pipelinedp4j.spark
+
+import com.google.privacy.differentialprivacy.pipelinedp4j.core.Encoder
+import com.google.privacy.differentialprivacy.pipelinedp4j.core.EncoderFactory
+import com.google.protobuf.Message
+import kotlin.reflect.KClass
+import org.apache.spark.sql.Encoders
+
+
+class SparkEncoder<T>(val encoder: org.apache.spark.sql.Encoder<T>) : Encoder<T>
+
+class SparkEncoderFactory(): EncoderFactory {
+
+    override fun strings(): Encoder<String> {
+        return SparkEncoder<String>(Encoders.STRING())
+    }
+
+    override fun doubles(): Encoder<Double> {
+        return SparkEncoder<Double>(Encoders.DOUBLE())
+    }
+
+    override fun ints(): Encoder<Int> {
+        return SparkEncoder<Int>(Encoders.INT())
+    }
+
+    override fun <T : Any> records(recordClass: KClass<T>): Encoder<T> {
+        return SparkEncoder(Encoders.bean(recordClass.java))
+    }
+
+    override fun <T : Message> protos(protoClass: KClass<T>): Encoder<T> {
+        TODO("Not yet implemented")
+    }
+
+    override fun <T1 : Any, T2 : Any> tuple2sOf(first: Encoder<T1>, second: Encoder<T2>): Encoder<Pair<T1, T2>> {
+        TODO("Not yet implemented")
+    }
+
+}
+

--- a/pipelinedp4j/tests/com/google/privacy/differentialprivacy/pipelinedp4j/spark/BUILD.bazel
+++ b/pipelinedp4j/tests/com/google/privacy/differentialprivacy/pipelinedp4j/spark/BUILD.bazel
@@ -1,0 +1,20 @@
+load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_test")
+
+kt_jvm_test(
+    name = "spark_tests",
+    srcs = [
+        "SparkCollectionTest.kt",
+        "SparkTests.kt",
+    ],
+    test_class = "com.google.privacy.differentialprivacy.pipelinedp4j.spark.SparkTests",
+    deps = [
+        "//main/com/google/privacy/differentialprivacy/pipelinedp4j/spark:spark_collections",
+        "@maven//:com_google_testparameterinjector_test_parameter_injector",
+        "@maven//:com_google_truth_truth",
+        "@maven//:junit_junit",
+        "@maven//:org_apache_spark_spark_core_2_12",
+        "@maven//:org_apache_spark_spark_sql_2_12",
+        "@maven//:org_apache_spark_spark_mllib_2_12",
+        "@maven//:org_apache_spark_spark_catalyst_2_12"
+    ],
+)

--- a/pipelinedp4j/tests/com/google/privacy/differentialprivacy/pipelinedp4j/spark/SparkCollectionTest.kt
+++ b/pipelinedp4j/tests/com/google/privacy/differentialprivacy/pipelinedp4j/spark/SparkCollectionTest.kt
@@ -1,0 +1,46 @@
+package com.google.privacy.differentialprivacy.pipelinedp4j.spark
+
+import com.google.common.truth.Truth
+import org.apache.spark.sql.Encoders
+import org.apache.spark.sql.SparkSession
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.junit.AfterClass
+import org.junit.BeforeClass
+
+@RunWith(JUnit4::class)
+class SparkCollectionTest {
+
+    companion object {
+        private lateinit var spark: SparkSession
+        @BeforeClass
+        @JvmStatic
+        fun setup() {
+            try {
+                spark = SparkSession.builder()
+                        .appName("Kotlin Spark Example")
+                        .master("local[*]")
+                        .getOrCreate()
+            } catch (e: Exception) {
+                e.printStackTrace()
+            }
+        }
+        @AfterClass
+        @JvmStatic
+        fun tearDown() {
+            // Stop SparkSession after all tests are done
+            spark.stop()
+        }
+    }
+    @Test
+    fun elementsEncoder_returnsCorrectEncoder() {
+        val dataset = spark.createDataset(listOf(1, 2, 3, 4, 5), Encoders.INT())
+        val sparkCollection = SparkCollection(dataset)
+        val result = sparkCollection.elementsEncoder
+
+        Truth.assertThat(result).isInstanceOf(SparkEncoder::class.java)
+        Truth.assertThat(result.encoder).isEqualTo(Encoders.INT())
+    }
+
+}

--- a/pipelinedp4j/tests/com/google/privacy/differentialprivacy/pipelinedp4j/spark/SparkTests.kt
+++ b/pipelinedp4j/tests/com/google/privacy/differentialprivacy/pipelinedp4j/spark/SparkTests.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.privacy.differentialprivacy.pipelinedp4j.spark
+
+import org.junit.runner.RunWith
+import org.junit.runners.Suite
+
+/** Provides a list of JUnit test classes to Bazel. When creating a new test class, add it here. */
+@RunWith(Suite::class)
+@Suite.SuiteClasses(SparkCollectionTest::class)
+class SparkTests {}


### PR DESCRIPTION
Spark kotlin setup JVM issue.
On running **SparkCollectionTest**, it fails while creating SparkSession. It complains with below error. It seems to be related to java and spark version incompatibility.

```java.lang.ExceptionInInitializerError
	at org.apache.spark.unsafe.array.ByteArrayMethods.<clinit>(ByteArrayMethods.java:56)
	at org.apache.spark.memory.MemoryManager.defaultPageSizeBytes$lzycompute(MemoryManager.scala:264)
	at org.apache.spark.memory.MemoryManager.defaultPageSizeBytes(MemoryManager.scala:254)
	at org.apache.spark.memory.MemoryManager.$anonfun$pageSizeBytes$1(MemoryManager.scala:273)
	at scala.runtime.java8.JFunction0$mcJ$sp.apply(JFunction0$mcJ$sp.java:23)
	at scala.Option.getOrElse(Option.scala:189)
	at org.apache.spark.memory.MemoryManager.<init>(MemoryManager.scala:273)
	at org.apache.spark.memory.UnifiedMemoryManager.<init>(UnifiedMemoryManager.scala:58)
	at org.apache.spark.memory.UnifiedMemoryManager$.apply(UnifiedMemoryManager.scala:207)
	at org.apache.spark.SparkEnv$.create(SparkEnv.scala:320)
	at org.apache.spark.SparkEnv$.createDriverEnv(SparkEnv.scala:194)
	at org.apache.spark.SparkContext.createSparkEnv(SparkContext.scala:279)
	at org.apache.spark.SparkContext.<init>(SparkContext.scala:464)
	at org.apache.spark.SparkContext$.getOrCreate(SparkContext.scala:2714)
	at org.apache.spark.sql.SparkSession$Builder.$anonfun$getOrCreate$2(SparkSession.scala:953)
	at scala.Option.getOrElse(Option.scala:189)
	at org.apache.spark.sql.SparkSession$Builder.getOrCreate(SparkSession.scala:947)
	at com.google.privacy.differentialprivacy.pipelinedp4j.spark.SparkCollectionTest$Companion.setup(SparkCollectionTest.kt:24)
	at com.google.privacy.differentialprivacy.pipelinedp4j.spark.SparkCollectionTest.setup(SparkCollectionTest.kt)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	at org.junit.internal.runners.statements.RunBefores.invokeMethod(RunBefores.java:33)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:24)
	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:413)
	at org.junit.runners.Suite.runChild(Suite.java:128)
	at org.junit.runners.Suite.runChild(Suite.java:27)
	at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
	at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:413)
	at com.google.testing.junit.runner.internal.junit4.CancellableRequestFactory$CancellableRunner.run(CancellableRequestFactory.java:108)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:115)
	at com.google.testing.junit.runner.junit4.JUnit4Runner.run(JUnit4Runner.java:116)
	at com.google.testing.junit.runner.BazelTestRunner.runTestsInSuite(BazelTestRunner.java:145)
	at com.google.testing.junit.runner.BazelTestRunner.main(BazelTestRunner.java:76)
Caused by: java.lang.IllegalStateException: java.lang.NoSuchMethodException: java.nio.DirectByteBuffer.<init>(long,int)
	at org.apache.spark.unsafe.Platform.<clinit>(Platform.java:113)
	... 44 more
Caused by: java.lang.NoSuchMethodException: java.nio.DirectByteBuffer.<init>(long,int)
	at java.base/java.lang.Class.getConstructor0(Class.java:3761)
	at java.base/java.lang.Class.getDeclaredConstructor(Class.java:2930)
	at org.apache.spark.unsafe.Platform.<clinit>(Platform.java:71)
	... 44 more```