### PR TITLE
Fix: correct `metrics` argument format in model.compile

### DIFF
--- a/python/dp_auditorium/dp_auditorium/testers/hockey_stick_tester.py
+++ b/python/dp_auditorium/dp_auditorium/testers/hockey_stick_tester.py
@@ -193,7 +193,7 @@ class HockeyStickPropertyTester(divergence_tester.DivergencePropertyTester):
             self._training_options.optimizer_learning_rate
         ),
         loss=tf.keras.losses.BinaryCrossentropy(from_logits=True),
-        metrics=tf.keras.metrics.BinaryAccuracy(threshold=0.0),
+        metrics=[tf.keras.metrics.BinaryAccuracy(threshold=0.0)],
     )
     features, labels = self._generate_inputs_to_model(
         samples_first_distribution,


### PR DESCRIPTION
This PR fixes a `ValueError` occurring when calling `model.compile()` in [hockey_stick_tester.py](https://github.com/google/differential-privacy/blob/main/python/dp_auditorium/dp_auditorium/testers/hockey_stick_tester.py#L196) with TensorFlow/Keras 2.15.0 (from [`requirements.txt`](https://github.com/google/differential-privacy/blob/main/python/dp_auditorium/requirements.txt#L107)). The `metrics` argument should be passed as a list, tuple, or dict, but it was originally passed as a single object. The fix updates the code to pass the `metrics` argument as a list, resolving the error.

**Original error message:**
```
ValueError: Expected `metrics` argument to be a list, tuple, or dict. Received instead: metrics=<BinaryAccuracy name=binary_accuracy> of type <class 'keras.src.metrics.accuracy_metrics.BinaryAccuracy'>"
```