### PR TITLE
Fix GitHub Actions by installing package deps

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -14,6 +14,8 @@ jobs:
         with:
           path: ~/.cache/bazel/
           key: bazel-cc-cache
+      - name: Install packages for the PostgreSQL extension
+        run: sudo apt-get install -y make libreadline-dev bison flex
       - name: Ensure bazelisk is installed
         run: bazelisk --version
       - name: Build C++ Workspace


### PR DESCRIPTION
PostgreSQL compile misses libreadline.  This was previously present in the GitHub Ubuntu Image but got removed.