### PR TITLE
Add FlinkRunner support in the Beam Example

### DIFF
--- a/examples/pipelinedp4j/README.md
+++ b/examples/pipelinedp4j/README.md
@@ -159,6 +159,32 @@ For Spark the output is written to a folder and the
 result is stored in a file whose name starts with `part-00000`: `cat
 output/part-00000<...>`
 
+#### Running with FlinkRunner (Beam)
+
+To run the Beam example with FlinkRunner, you need to use the `flink-runner` profile and add the `--runner=FlinkRunner` and `--reIterableGroupByKeyResult` parameters.
+
+The `--reIterableGroupByKeyResult` parameter is required because FlinkRunner's GroupByKey operation produces results that can only be iterated once by default. Since PipelineDP4j needs to iterate over grouped results multiple times for differential privacy computations, this flag enables re-iterable results.
+
+First, build the package with the `flink-runner` profile:
+
+```shell
+mvn clean package -Pflink-runner
+```
+
+Then run with Flink CLI:
+
+```shell
+$FLINK_HOME/bin/flink run \
+  -c com.google.privacy.differentialprivacy.pipelinedp4j.examples.BeamExample \
+  target/beam-1.0-SNAPSHOT.jar \
+  --runner=FlinkRunner \
+  --inputFilePath=<absolute_path_to>/netflix_data.csv \
+  --outputFilePath=output.txt \
+  --reIterableGroupByKeyResult
+```
+
+View the results with `cat output.txt`.
+
 ### Running on Google Cloud Platform
 
 This section explains the examples on Google Cloud Platform (GCP).

--- a/examples/pipelinedp4j/WORKSPACE.bazel
+++ b/examples/pipelinedp4j/WORKSPACE.bazel
@@ -86,6 +86,7 @@ maven_install(
         "com.google.protobuf:protobuf-kotlin:4.30.1",
         "com.google.errorprone:error_prone_annotations:2.38.0",
         "org.apache.beam:beam-runners-direct-java:%s" % BEAM_TAG,
+        "org.apache.beam:beam-runners-flink-1.18:%s" % BEAM_TAG,
         "org.apache.beam:beam-sdks-java-core:%s" % BEAM_TAG,
         "org.apache.beam:beam-sdks-java-extensions-avro:%s" % BEAM_TAG,
         "org.apache.beam:beam-sdks-java-extensions-protobuf:%s" % BEAM_TAG,

--- a/examples/pipelinedp4j/beam/pom.xml
+++ b/examples/pipelinedp4j/beam/pom.xml
@@ -32,6 +32,7 @@
 
     <properties>
         <beam.version>2.63.0</beam.version>
+        <flink.version>1.18</flink.version>
 
         <!-- Otherwise you get errors like https://shorturl.at/7mfCi -->
         <exec.cleanupDaemonThreads>false</exec.cleanupDaemonThreads>
@@ -83,6 +84,67 @@
                     <scope>runtime</scope>
                 </dependency>
             </dependencies>
+        </profile>
+
+        <profile>
+            <id>flink-runner</id>
+            <!-- Makes the FlinkRunner available when running a pipeline. -->
+            <dependencies>
+                <dependency>
+                    <groupId>org.apache.beam</groupId>
+                    <artifactId>beam-runners-flink-${flink.version}</artifactId>
+                    <version>${beam.version}</version>
+                    <scope>runtime</scope>
+                </dependency>
+            </dependencies>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-shade-plugin</artifactId>
+                        <version>3.1.1</version>
+                        <executions>
+                            <execution>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>shade</goal>
+                                </goals>
+                                <configuration>
+                                    <artifactSet>
+                                        <excludes>
+                                            <exclude>com.google.code.findbugs:jsr305</exclude>
+                                        </excludes>
+                                    </artifactSet>
+                                    <filters>
+                                        <filter>
+                                            <!-- Do not copy the signatures in the META-INF folder.
+                                            Otherwise, this might cause SecurityExceptions when using the JAR. -->
+                                            <artifact>*:*</artifact>
+                                            <excludes>
+                                                <exclude>META-INF/*.SF</exclude>
+                                                <exclude>META-INF/*.DSA</exclude>
+                                                <exclude>META-INF/*.RSA</exclude>
+                                            </excludes>
+                                        </filter>
+                                        <filter>
+                                            <artifact>com.fasterxml.jackson.module:jackson-module-scala*</artifact>
+                                            <excludes>
+                                                <exclude>**</exclude>
+                                            </excludes>
+                                        </filter>
+                                    </filters>
+                                    <transformers>
+                                        <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                            <mainClass>com.google.privacy.differentialprivacy.pipelinedp4j.examples.BeamExample</mainClass>
+                                        </transformer>
+                                        <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                                    </transformers>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
     </profiles>
 </project>


### PR DESCRIPTION
Before starting native Flink support, I tested Beam’s FlinkRunner and it worked well. 
It cannot be run with exec:java due to Flink dependency conflicts; however, it runs correctly on a Flink cluster.

## Test Result
<img width="933" height="943" alt="image" src="https://github.com/user-attachments/assets/a7f07bf2-f12c-4730-b6fb-8faf9b014aca" />
