### PR TITLE
Upgrade GitHub Actions for Node 24 compatibility

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -8,9 +8,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Mount Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: ~/.cache/bazel/
           key: bazel-cc-cache
@@ -36,9 +36,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Mount Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: ~/.cache/bazel/
           key: bazel-java-cache
@@ -59,9 +59,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Mount Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: ~/.cache/bazel/
           key: bazel-pipelinedp4j-cache
@@ -99,9 +99,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Mount Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: ~/.cache/bazel/
           key: bazel-zetasql-examples-cache
@@ -116,9 +116,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Set up Python 3.10
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: '3.10'
       - name: Install Python dependencies
@@ -126,7 +126,7 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install --upgrade setuptools
       - name: Mount Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: ~/.cache/bazel/
           key: bazel-python-cache

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -17,10 +17,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v6
 
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v6
       with:
         go-version: 1.22
 

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -8,16 +8,16 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Cache Maven dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('examples/pipelinedp4j/pom.xml', 'examples/pipelinedp4j/**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
       - name: Set up JDK 11
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v5
         with:
           java-version: '11'
           distribution: 'temurin'


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions to ensure compatibility with Node 24, as Node 20 will reach end-of-life in April 2026.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `actions/cache` | [`v3`](https://github.com/actions/cache/releases/tag/v3) | [`v5`](https://github.com/actions/cache/releases/tag/v5) | [Release](https://github.com/actions/cache/releases/tag/v5) | bazel.yml, maven.yml |
| `actions/checkout` | [`v2`](https://github.com/actions/checkout/releases/tag/v2), [`v3`](https://github.com/actions/checkout/releases/tag/v3) | [`v6`](https://github.com/actions/checkout/releases/tag/v6) | [Release](https://github.com/actions/checkout/releases/tag/v6) | bazel.yml, go.yml, maven.yml |
| `actions/setup-go` | [`v2`](https://github.com/actions/setup-go/releases/tag/v2) | [`v6`](https://github.com/actions/setup-go/releases/tag/v6) | [Release](https://github.com/actions/setup-go/releases/tag/v6) | go.yml |
| `actions/setup-java` | [`v3`](https://github.com/actions/setup-java/releases/tag/v3) | [`v5`](https://github.com/actions/setup-java/releases/tag/v5) | [Release](https://github.com/actions/setup-java/releases/tag/v5) | maven.yml |
| `actions/setup-python` | [`v4`](https://github.com/actions/setup-python/releases/tag/v4) | [`v6`](https://github.com/actions/setup-python/releases/tag/v6) | [Release](https://github.com/actions/setup-python/releases/tag/v6) | bazel.yml |

## Context

Per [GitHub's announcement](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), Node 20 is being deprecated and runners will begin using Node 24 by default starting March 4th, 2026.

### Why this matters

- **Node 20 EOL**: April 2026
- **Node 24 default**: March 4th, 2026
- **Action**: Update to latest action versions that support Node 24

### ⚠️ Breaking Changes

- **actions/cache** (v3 → v5):
  - ⚠️ v4 uses a new caching backend - existing caches may not be reused on first run

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
