### PR TITLE
Reject NaN in ClampFloat64 and check L1 sensitivity overflow in Laplace noise

### DIFF
--- a/go/dpagg/helpers.go
+++ b/go/dpagg/helpers.go
@@ -27,10 +27,15 @@ var LargestRepresentableDelta = 1 - math.Pow(2, -53)
 // ClampFloat64 clamps e within lower and upper, such that lower is returned
 // if e < lower, and upper is returned if e > upper. Otherwise, e is returned.
 func ClampFloat64(e, lower, upper float64) (float64, error) {
+	if math.IsNaN(lower) || math.IsNaN(upper) {
+		return 0, fmt.Errorf("bounds must not be NaN, got lower = %v, upper = %v", lower, upper)
+	}
 	if lower > upper {
 		return 0, fmt.Errorf("lower must be less than or equal to upper, got lower = %v, upper = %v", lower, upper)
 	}
-
+	if math.IsNaN(e) || math.IsInf(e, 0) {
+		return lower, nil
+	}
 	if e > upper {
 		return upper, nil
 	}

--- a/go/noise/laplace_noise.go
+++ b/go/noise/laplace_noise.go
@@ -17,6 +17,7 @@
 package noise
 
 import (
+	"fmt"
 	"math"
 
 	"github.com/google/differential-privacy/go/v4/checks"
@@ -61,7 +62,11 @@ func (laplace) AddNoiseFloat64(x float64, l0Sensitivity int64, lInfSensitivity, 
 	if err := checkArgsLaplace(l0Sensitivity, lInfSensitivity, epsilon, delta); err != nil {
 		return 0, err
 	}
-	return addLaplaceFloat64(x, epsilon, lInfSensitivity*float64(l0Sensitivity) /* l1Sensitivity */), nil
+	l1Sensitivity := lInfSensitivity * float64(l0Sensitivity)
+	if math.IsInf(l1Sensitivity, 0) || math.IsNaN(l1Sensitivity) {
+		return 0, fmt.Errorf("l1Sensitivity overflows: lInfSensitivity=%v * l0Sensitivity=%v produces %v", lInfSensitivity, l0Sensitivity, l1Sensitivity)
+	}
+	return addLaplaceFloat64(x, epsilon, l1Sensitivity), nil
 }
 
 // AddNoiseInt64 adds Laplace noise to the specified int64 x so that the
@@ -71,7 +76,11 @@ func (laplace) AddNoiseInt64(x, l0Sensitivity, lInfSensitivity int64, epsilon, d
 	if err := checkArgsLaplace(l0Sensitivity, float64(lInfSensitivity), epsilon, delta); err != nil {
 		return 0, err
 	}
-	return addLaplaceInt64(x, epsilon, lInfSensitivity*l0Sensitivity /* l1Sensitivity */), nil
+	l1Sensitivity := lInfSensitivity * l0Sensitivity
+	if (l0Sensitivity != 0 && l1Sensitivity/l0Sensitivity != lInfSensitivity) || l1Sensitivity < 0 {
+		return 0, fmt.Errorf("l1Sensitivity overflows: lInfSensitivity=%v * l0Sensitivity=%v wraps to %v", lInfSensitivity, l0Sensitivity, l1Sensitivity)
+	}
+	return addLaplaceInt64(x, epsilon, l1Sensitivity), nil
 }
 
 // Threshold returns the smallest threshold k to use in a differentially private


### PR DESCRIPTION
ClampFloat64 does not handle NaN inputs. Because IEEE 754 comparisons with NaN return false, NaN passes through clamping untouched and propagates into DP results, breaking the privacy guarantee.

NaN reaches ClampFloat64 through L1 sensitivity overflow in the Laplace noise layer: when lInfSensitivity * l0Sensitivity overflows to +Inf, ceilPowerOfTwo returns NaN, and the noise computation produces NaN throughout.

This patch:
- Rejects NaN/Inf bounds in ClampFloat64 with an error
- Clamps NaN/Inf values to lower bound instead of passing them through
- Checks the L1 sensitivity product for overflow in AddNoiseFloat64 before use
- Checks for int64 wrap in AddNoiseInt64 where silent overflow turns the product negative