### PR TITLE
fix: handle NaN in ClampFloat64 and L1 sensitivity overflow in Laplac…

### DIFF
--- a/go/dpagg/helpers.go
+++ b/go/dpagg/helpers.go
@@ -27,6 +27,9 @@ var LargestRepresentableDelta = 1 - math.Pow(2, -53)
 // ClampFloat64 clamps e within lower and upper, such that lower is returned
 // if e < lower, and upper is returned if e > upper. Otherwise, e is returned.
 func ClampFloat64(e, lower, upper float64) (float64, error) {
+	if math.IsNaN(e) {
+		return lower, fmt.Errorf("e is NaN, clamping to lower bound %v", lower)
+	}
 	if lower > upper {
 		return 0, fmt.Errorf("lower must be less than or equal to upper, got lower = %v, upper = %v", lower, upper)
 	}

--- a/go/dpagg/helpers_test.go
+++ b/go/dpagg/helpers_test.go
@@ -17,6 +17,7 @@
 package dpagg
 
 import (
+	"math"
 	"testing"
 )
 
@@ -126,6 +127,22 @@ func TestClampFloat64(t *testing.T) {
 			lower:        5,
 			upper:        2,
 			want:         0,
+			wantErr:      true,
+		},
+		{
+			desc:         "NaN value is clamped to lower bound with error",
+			valueToClamp: math.NaN(),
+			lower:        0,
+			upper:        10,
+			want:         0,
+			wantErr:      true,
+		},
+		{
+			desc:         "NaN value with negative lower bound",
+			valueToClamp: math.NaN(),
+			lower:        -5,
+			upper:        5,
+			want:         -5,
 			wantErr:      true,
 		},
 	} {

--- a/go/noise/laplace_noise.go
+++ b/go/noise/laplace_noise.go
@@ -17,6 +17,7 @@
 package noise
 
 import (
+	"fmt"
 	"math"
 
 	"github.com/google/differential-privacy/go/v4/checks"
@@ -61,7 +62,11 @@ func (laplace) AddNoiseFloat64(x float64, l0Sensitivity int64, lInfSensitivity, 
 	if err := checkArgsLaplace(l0Sensitivity, lInfSensitivity, epsilon, delta); err != nil {
 		return 0, err
 	}
-	return addLaplaceFloat64(x, epsilon, lInfSensitivity*float64(l0Sensitivity) /* l1Sensitivity */), nil
+	l1Sensitivity := lInfSensitivity * float64(l0Sensitivity)
+	if math.IsInf(l1Sensitivity, 0) || math.IsNaN(l1Sensitivity) {
+		return 0, fmt.Errorf("l1Sensitivity = lInfSensitivity * l0Sensitivity overflows: %v * %v = %v, must be finite", lInfSensitivity, l0Sensitivity, l1Sensitivity)
+	}
+	return addLaplaceFloat64(x, epsilon, l1Sensitivity), nil
 }
 
 // AddNoiseInt64 adds Laplace noise to the specified int64 x so that the
@@ -71,7 +76,13 @@ func (laplace) AddNoiseInt64(x, l0Sensitivity, lInfSensitivity int64, epsilon, d
 	if err := checkArgsLaplace(l0Sensitivity, float64(lInfSensitivity), epsilon, delta); err != nil {
 		return 0, err
 	}
-	return addLaplaceInt64(x, epsilon, lInfSensitivity*l0Sensitivity /* l1Sensitivity */), nil
+	// Check for int64 overflow: if both operands have the same sign and the
+	// product divided by one operand does not equal the other, it overflowed.
+	l1Sensitivity := lInfSensitivity * l0Sensitivity
+	if l0Sensitivity != 0 && l1Sensitivity/l0Sensitivity != lInfSensitivity {
+		return 0, fmt.Errorf("l1Sensitivity = lInfSensitivity * l0Sensitivity overflows int64: %v * %v", lInfSensitivity, l0Sensitivity)
+	}
+	return addLaplaceInt64(x, epsilon, l1Sensitivity), nil
 }
 
 // Threshold returns the smallest threshold k to use in a differentially private

--- a/go/noise/laplace_noise_test.go
+++ b/go/noise/laplace_noise_test.go
@@ -873,3 +873,22 @@ func TestGeometricStatistics(t *testing.T) {
 		}
 	}
 }
+
+func TestAddNoiseFloat64RejectsL1Overflow(t *testing.T) {
+	l := Laplace()
+	// lInfSensitivity=1e308 is valid (finite, positive) and l0Sensitivity=2
+	// is valid, but their product overflows to +Inf.
+	_, err := l.AddNoiseFloat64(0, 2, 1e308, 1.0, 0)
+	if err == nil {
+		t.Error("AddNoiseFloat64: expected error for L1 sensitivity overflow, got nil")
+	}
+}
+
+func TestAddNoiseInt64RejectsL1Overflow(t *testing.T) {
+	l := Laplace()
+	// Both values are valid individually but their product overflows int64.
+	_, err := l.AddNoiseInt64(0, math.MaxInt64, 2, 1.0, 0)
+	if err == nil {
+		t.Error("AddNoiseInt64: expected error for L1 sensitivity overflow, got nil")
+	}
+}


### PR DESCRIPTION
## Problem

`ClampFloat64` in `go/dpagg/helpers.go` does not handle NaN inputs. IEEE 754 comparisons with NaN always return false, so NaN passes through both the `> upper` and `< lower` checks and gets returned as-is.

NaN reaches `ClampFloat64` through an L1 sensitivity overflow in the Laplace noise layer. In `AddNoiseFloat64`, `l1 = lInfSensitivity * float64(l0Sensitivity)` can overflow to +Inf when both operands are individually valid. `ceilPowerOfTwo(+Inf)` returns NaN, which propagates through the entire noise computation. The same issue affects `AddNoiseInt64` where the int64 multiplication wraps silently.

Aggregations like `BoundedVariance`, `BoundedMean`, and `BoundedStandardDeviation` are affected since they derive internal bounds that can push `lInfSensitivity` close to `MaxFloat64`.

## Fix

- Add a `math.IsNaN(e)` check at the top of `ClampFloat64`, returning the lower bound with an error.
- Check that `l1Sensitivity` is finite after multiplication in `AddNoiseFloat64`.
- Check for int64 overflow after multiplication in `AddNoiseInt64`.
- Add tests for all three cases.

Related: https://issuetracker.google.com/issues/500383618