### PR TITLE
Fix Gaussian sensitivity for replace-one adjacency

### DIFF
--- a/python/dp_accounting/dp_accounting/rdp/rdp_privacy_accountant.py
+++ b/python/dp_accounting/dp_accounting/rdp/rdp_privacy_accountant.py
@@ -1042,8 +1042,13 @@ class RdpAccountant(privacy_accountant.PrivacyAccountant):
       return None
     elif isinstance(event, dp_event.GaussianDpEvent):
       if do_compose:
+        noise_multiplier = event.noise_multiplier
+        if self._neighboring_relation is NeighborRel.REPLACE_ONE:
+          # GaussianDpEvent normalizes noise by the per-record norm bound C.
+          # Under replace-one adjacency, the sensitivity of the sum is 2C.
+          noise_multiplier /= 2
         self._rdp += count * _compute_rdp_poisson_subsampled_gaussian(
-            q=1.0, noise_multiplier=event.noise_multiplier, orders=self._orders  # pyrefly: ignore[bad-argument-type]
+            q=1.0, noise_multiplier=noise_multiplier, orders=self._orders  # pyrefly: ignore[bad-argument-type]
         )
       return None
     elif isinstance(event, dp_event.ZCDpEvent):
@@ -1139,9 +1144,11 @@ class RdpAccountant(privacy_accountant.PrivacyAccountant):
             ),
         )
       if do_compose:
+        # Fixed-size sampling uses replace-one adjacency. GaussianDpEvent
+        # normalizes by C, while the sampled sum has sensitivity 2C.
         self._rdp += count * _compute_rdp_sample_wor_gaussian(
             q=event.sample_size / event.source_dataset_size,
-            noise_multiplier=sigma_or_bad_event,
+            noise_multiplier=sigma_or_bad_event / 2,
             orders=self._orders,  # pyrefly: ignore[bad-argument-type]
         )
       return None

--- a/python/dp_accounting/dp_accounting/rdp/rdp_privacy_accountant_test.py
+++ b/python/dp_accounting/dp_accounting/rdp/rdp_privacy_accountant_test.py
@@ -251,6 +251,30 @@ class RdpPrivacyAccountantTest(
     accountant.compose(event)
     self.assertAlmostEqual(accountant._rdp[0], alpha / (2 * sigma**2))
 
+  def test_compute_rdp_gaussian_replace_one(self):
+    alpha = 3.14159
+    sigma = 2.71828
+    event = dp_event.GaussianDpEvent(sigma)
+    accountant = rdp_privacy_accountant.RdpAccountant(
+        orders=[alpha],
+        neighboring_relation=privacy_accountant.NeighboringRelation.REPLACE_ONE,
+    )
+    accountant.compose(event)
+    self.assertAlmostEqual(accountant._rdp[0], 2 * alpha / sigma**2)
+
+  def test_compute_rdp_full_sample_without_replacement_gaussian(self):
+    alpha = 3.14159
+    sigma = 2.71828
+    event = dp_event.SampledWithoutReplacementDpEvent(
+        100, 100, dp_event.GaussianDpEvent(sigma)
+    )
+    accountant = rdp_privacy_accountant.RdpAccountant(
+        orders=[alpha],
+        neighboring_relation=privacy_accountant.NeighboringRelation.REPLACE_ONE,
+    )
+    accountant.compose(event)
+    self.assertAlmostEqual(accountant._rdp[0], 2 * alpha / sigma**2)
+
   def test_compute_rdp_multi_gaussian(self):
     alpha = 3.14159
     sigma1, sigma2 = 2.71828, 6.28319


### PR DESCRIPTION
## Summary
- account for the 2C sensitivity of clipped sums under replace-one adjacency
- apply the same sensitivity scaling to fixed-size sampling without replacement
- add regression tests for direct and fully sampled Gaussian events

## Why
`GaussianDpEvent` defines its noise multiplier as `s / C`, where `C` is the per-record norm bound. Under replace-one adjacency, two clipped records may differ by `2C`, so formulas normalized by L2 sensitivity must receive half that multiplier. Without this adjustment, RDP can be underestimated by a factor of four.

Fixes #378.

## Tests
- `python3 -m pytest python/dp_accounting/dp_accounting/rdp/rdp_privacy_accountant_test.py -q` (160 passed)